### PR TITLE
WIP: Add settings to get rid of hard coded paths

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+*.jl text
+*.py text
 *.rs text
 *.toml rext
-*.lock text
+*.yaml text
+Cargo.lock text eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,17 +525,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,42 +798,43 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "clap_builder",
  "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.3",
- "once_cell",
- "strsim 0.10.0",
- "termcolor",
- "textwrap",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.25"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
- "heck 0.4.1",
- "proc-macro-error",
+ "heck",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.77",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "codepage"
@@ -1117,7 +1107,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.77",
 ]
 
@@ -1792,24 +1782,9 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1867,6 +1842,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "toml",
  "umya-spreadsheet",
  "warp",
  "zmq",
@@ -2696,12 +2672,6 @@ dependencies = [
  "dlv-list",
  "hashbrown 0.13.2",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
 
 [[package]]
 name = "parking"
@@ -4048,12 +4018,6 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -4070,7 +4034,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -4165,7 +4129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
  "cfg-expr",
- "heck 0.5.0",
+ "heck",
  "pkg-config",
  "toml",
  "version-compare",
@@ -4206,21 +4170,6 @@ dependencies = [
  "rustversion",
  "winapi",
 ]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -615,6 +615,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -897,6 +900,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "config"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7328b20597b53c2454f0b1919720c25c7339051c02b72b7e05409e00b14132be"
+dependencies = [
+ "async-trait",
+ "convert_case",
+ "json5",
+ "lazy_static",
+ "nom",
+ "pathdiff",
+ "ron",
+ "rust-ini",
+ "serde",
+ "serde_json",
+ "toml",
+ "yaml-rust",
+]
+
+[[package]]
 name = "const-random"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -914,6 +937,15 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1145,6 +1177,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,6 +1193,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1163,6 +1216,15 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
 ]
 
 [[package]]
@@ -1688,6 +1750,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+
+[[package]]
+name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
@@ -1770,7 +1838,9 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "clap",
+ "config",
  "csv",
+ "directories",
  "engine",
  "env_logger",
  "fs",
@@ -1793,6 +1863,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "serde_yaml",
+ "tempfile",
  "thiserror",
  "time",
  "tokio",
@@ -2093,6 +2164,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "jwalk"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2302,6 +2384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,6 +2493,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2575,12 +2673,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-float"
 version = "3.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1e1c390732d15f1d48471625cd92d154e66db2c56645e29a9cd26f4699f72dc"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "ordered-multimap"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ed8acf08e98e744e5384c8bc63ceb0364e68a6854187221c18df61c4797690e"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -2640,10 +2754,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8992df7ccb4aa439069561f4d1f391ad59eb7a8ea718fef6e4623ae09f40e291"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "pest"
+version = "2.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
+dependencies = [
+ "once_cell",
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "phf"
@@ -3478,6 +3643,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64 0.21.7",
+ "bitflags 2.6.0",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2a3bcec1f113553ef1c88aae6c020a369d03d55b58de9869a0908930385091"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4281,6 +4468,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "umya-spreadsheet"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "1.0.60"
 prettytable = "0.10.0"
 interprocess = "2.1.0"
 bytes = "1.6.0"
-clap = { version = "3", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 engine = "0.0.0"
 arrow-ipc = "51.0"
 zmq = "0.10.0"
@@ -48,6 +48,7 @@ serde_with = "3.9.0"
 quick-xml = "0.25.0"
 directories = "5.0"
 config = "0.14"
+toml = "0.8"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "rt", "time", "sync"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,9 @@ log = "0.4.22"
 linked-hash-map = "0.5.6"
 serde_with = "3.9.0"
 quick-xml = "0.25.0"
+directories = "5.0"
+config = "0.14"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "rt", "time", "sync"]}
+tempfile = "3.12"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+newline_style="Native"

--- a/src/Pr_ArrowConnection.jl
+++ b/src/Pr_ArrowConnection.jl
@@ -1,9 +1,7 @@
 import Pkg
 
-script_project_path = ARGS[1]
-predicer_project_path = ARGS[2]
+predicer_project_path = ARGS[1]
 
-Pkg.activate(script_project_path)
 Pkg.instantiate()
 Pkg.add("Arrow")
 Pkg.add("ZMQ")

--- a/src/Pr_ArrowConnection.jl
+++ b/src/Pr_ArrowConnection.jl
@@ -1,14 +1,12 @@
 import Pkg
 
-# Activate the project environment
-Pkg.activate("C:\\users\\enessi\\Documents\\hertta")
+script_project_path = ARGS[1]
+predicer_project_path = ARGS[2]
 
-# Instantiate all dependencies
+Pkg.activate(script_project_path)
 Pkg.instantiate()
-
 Pkg.add("Arrow")
 Pkg.add("ZMQ")
-
 println("Running Julia script with all dependencies activated and instantiated.")
 
 using Arrow
@@ -18,13 +16,9 @@ using OrderedCollections
 using TimeZones
 using Dates
 
-# Navigate to Predicer directory and activate the environment
-cd("C:\\users\\enessi\\Documents\\hertta-kaikki\\hertta-addon\\hertta\\Predicer")
-
+cd(predicer_project_path)
 Pkg.activate(".")
 Pkg.instantiate()
-
-# Use the Predicer module
 using Predicer
 
 zmq_context = Context()
@@ -41,7 +35,7 @@ function send_dataframe(df::DataFrame, df_type::String, port::Int)
     socket = Socket(zmq_context, REQ)
     ZMQ.connect(socket, "tcp://localhost:5555")
     ZMQ.send(socket, "Take this! $df_type $endpoint")
-    
+
     ready_confirmation = String(ZMQ.recv(socket))
     if ready_confirmation == "ready to receive"
         ZMQ.send(push_socket, take!(buffer))
@@ -59,8 +53,6 @@ function main()
     ZMQ.connect(socket, "tcp://localhost:5555")
     println("Sending request...")
     ZMQ.send(socket, "Hello")
-
-    # Keywords list
     keywords = [
         "temps",
         "setup",
@@ -91,44 +83,35 @@ function main()
         "fixed_ts",
         "balance_prices"
     ]
-
-    # Define sheetname categories
     sheetnames_system = [
-        "setup", "nodes", "processes", "groups", "process_topology", 
-        "node_history", "node_delay", "node_diffusion", "inflow_blocks", 
-        "markets", "scenarios", "efficiencies", "reserve_type", "risk", 
+        "setup", "nodes", "processes", "groups", "process_topology",
+        "node_history", "node_delay", "node_diffusion", "inflow_blocks",
+        "markets", "scenarios", "efficiencies", "reserve_type", "risk",
         "cap_ts", "gen_constraint", "constraints", "bid_slots"
     ]
     sheetnames_timeseries = [
-        "cf", "inflow", "market_prices", "reserve_realisation", 
-        "reserve_activation_price", "price", "eff_ts", "fixed_ts", 
+        "cf", "inflow", "market_prices", "reserve_realisation",
+        "reserve_activation_price", "price", "eff_ts", "fixed_ts",
         "balance_prices"
     ]
-
-    # Initialize data structures to store the data tables
     data_dict = OrderedDict{String, DataFrame}()
-
-    # Loop to receive multiple tables
     while true
         println("Waiting to receive data...")
         data = ZMQ.recv(socket)
         println("Received data, checking if it is END signal...")
-        if isempty(data) || String(data) == "END"  # Check for end signal
+        if isempty(data) || String(data) == "END"
             println("Received END signal or empty data, breaking the loop.")
             break
         end
         println("Processing received data...")
         table = Arrow.Table(IOBuffer(data, read=true, write=false))
-        df = DataFrame(table)  # Convert Arrow table to DataFrame
+        df = DataFrame(table)
         push!(data_dict, (keywords[length(data_dict) + 1] => df))
         println("Received DataFrame for keyword $(keywords[length(data_dict)]):")
-        #println(df)  # Print the DataFrame
-        # Send acknowledgment
         println("Sending acknowledgment for keyword $(keywords[length(data_dict)])...")
         ZMQ.send(socket, "ACK")
     end
 
-    # Function to convert 't' column to DateTime in a DataFrame
     function convert_t_to_datetime!(df::DataFrame)
         if hasproperty(df, :t)
             println("Found 't' column with values: ", df.t)
@@ -166,13 +149,13 @@ function main()
         elseif key in sheetnames_system
             system_data[key] = df
             println("Added to system_data: ", key)
-            
+
             # Convert 't' column to DateTime in system_data
             convert_t_to_datetime!(system_data[key])
         elseif key in sheetnames_timeseries
             timeseries_data[key] = df
             println("Added to timeseries_data: ", key)
-            
+
             # Convert 't' column to DateTime in timeseries_data
             convert_t_to_datetime!(timeseries_data[key])
         else
@@ -196,49 +179,31 @@ function main()
         println("Key: $key")
         println(df)
     end
-    
-    
+
     input_data = Predicer.compile_input_data(system_data, timeseries_data, temporals)
     mc, input_data = Predicer.generate_model(input_data)
     Predicer.solve_model(mc)
     result_dataframes = Predicer.get_all_result_dataframes(mc, input_data)
 
-    # Define a base port number for the push sockets
     base_port = 5237
-
     for (i, type) in enumerate(keys(result_dataframes))
         df = result_dataframes[type]
-        
-        # Print dataframe for inspection
-        println("DataFrame for type $type:")
-        println(df)
-        
-        # Serialize dataframe to Arrow buffer
         buffer = IOBuffer()
         Arrow.write(buffer, df)
-
-        # Send serialized Arrow buffer over ZeroMQ
         push_port = base_port + i
         endpoint = "tcp://localhost:$push_port"
         push_socket = Socket(zmq_context, PUSH)
         ZMQ.bind(push_socket, "tcp://*:$push_port")
         ZMQ.send(socket, "Take this! $(endpoint)")
-        
         ready_confirmation = String(ZMQ.recv(socket))
         if ready_confirmation == "ready to receive"
             ZMQ.send(push_socket, take!(buffer))
         else
             println("Receiver not ready to receive $ready_confirmation")
         end
-        
         ZMQ.close(push_socket)
     end
-
-    
-
-    # Send Quit command to the server
     ZMQ.send(socket, "Quit")
-
     ZMQ.close(socket)
     ZMQ.close(zmq_context)
 end

--- a/src/arrow_errors.rs
+++ b/src/arrow_errors.rs
@@ -1,4 +1,3 @@
-
 use arrow::error::ArrowError;
 use thiserror::Error;
 
@@ -17,4 +16,3 @@ pub enum DataConversionError {
     #[error("Empty or default input found for crucial parameters")]
     _EmptyOrDefaultInput,
 }
-

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,13 +1,13 @@
+use arrow::error::ArrowError;
+use serde::{Deserialize, Serialize};
+use std::error::Error;
 use std::fmt::{self};
 use warp::reject::Reject;
-use std::error::Error;
-use arrow::error::ArrowError;
-use serde::{Serialize, Deserialize};
 
 /// A custom error type for representing errors from Julia.
 ///
 /// This struct is used to encapsulate errors that occur within the Julia environment when
-/// interfacing with Rust. 
+/// interfacing with Rust.
 ///
 #[derive(Debug)]
 pub struct JuliaError(pub String);
@@ -23,8 +23,8 @@ impl Reject for JuliaError {}
 
 /// Represents errors that occur during the control and execution of various processes.
 ///
-/// This struct encapsulates errors specific to process control and execution, providing a 
-/// consistent way to handle such errors in Rust code. It is useful for signaling issues that 
+/// This struct encapsulates errors specific to process control and execution, providing a
+/// consistent way to handle such errors in Rust code. It is useful for signaling issues that
 /// arise during operations like controlling the devices etc.
 ///
 
@@ -117,7 +117,9 @@ pub struct TaskError {
 
 impl TaskError {
     pub fn _new(msg: &str) -> TaskError {
-        TaskError { message: msg.to_string() }
+        TaskError {
+            message: msg.to_string(),
+        }
     }
 }
 

--- a/src/event_loop.rs
+++ b/src/event_loop.rs
@@ -102,14 +102,13 @@ pub async fn start_julia_local(
     let push_port = find_available_port().await?;
     env::set_var("PUSH_PORT", push_port.to_string());
     println!("starting Julia from {}", julia_exec);
-    println!("using Julia project {}", predicer_runner_project);
+    println!("Predicer runner script in {}", predicer_runner_script);
+    println!("using project in {}", predicer_runner_project);
     println!("using Predicer in {}", predicer_project);
-    println!("Predicer script in {}", predicer_runner_script);
     let status = Command::new(julia_exec)
         .arg(format!("--project={}", predicer_runner_project))
         .arg(predicer_runner_script)
-        .arg(predicer_runner_project)
-        .arg("predicer project")
+        .arg(predicer_project)
         .status()?;
     Ok(status)
 }

--- a/src/input_data.rs
+++ b/src/input_data.rs
@@ -1,14 +1,13 @@
-
 //use crate::errors;
 use crate::utilities;
 
-use serde::{self, Serialize, Deserialize, Deserializer, Serializer};
-use chrono::{DateTime, FixedOffset};
-use std::collections::BTreeMap;
 use arrow::record_batch::RecordBatch;
-use std::sync::Arc;
+use chrono::{DateTime, FixedOffset};
 use serde::de::{self, MapAccess, Visitor};
+use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
+use std::collections::BTreeMap;
 use std::fmt;
+use std::sync::Arc;
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
 pub struct OptimizationData {
@@ -52,8 +51,7 @@ pub struct Temporals {
     pub dtf: f64,
     pub is_variable_dt: bool,
     pub variable_dt: Vec<(String, f64)>,
-    pub ts_format: String, 
-    
+    pub ts_format: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -99,7 +97,7 @@ pub struct Process {
     pub cf: TimeSeriesData,
     pub eff_ts: TimeSeriesData,
     pub eff_ops: Vec<String>,
-    pub eff_fun: Vec<(f64,f64)>
+    pub eff_fun: Vec<(f64, f64)>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
@@ -133,7 +131,7 @@ pub struct NodeHistory {
 pub struct Market {
     pub name: String,
     pub m_type: String,
-    pub node: String, 
+    pub node: String,
     pub processgroup: String,
     pub direction: String,
     pub realisation: TimeSeriesData,
@@ -186,7 +184,9 @@ where
         type Value = BTreeMap<(String, String), f64>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-            formatter.write_str("a map with string keys formatted as tuple (String, String) and float values")
+            formatter.write_str(
+                "a map with string keys formatted as tuple (String, String) and float values",
+            )
         }
 
         fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
@@ -214,7 +214,9 @@ where
     deserializer.deserialize_map(PricesVisitor)
 }
 
-fn deserialize_market_price_allocation<'de, D>(deserializer: D) -> Result<BTreeMap<(String, String), (String, String)>, D::Error>
+fn deserialize_market_price_allocation<'de, D>(
+    deserializer: D,
+) -> Result<BTreeMap<(String, String), (String, String)>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -240,7 +242,9 @@ where
                     .map(String::from)
                     .collect::<Vec<_>>();
                 if key.len() != 2 || value.len() != 2 {
-                    return Err(de::Error::custom("invalid key format for market_price_allocation"));
+                    return Err(de::Error::custom(
+                        "invalid key format for market_price_allocation",
+                    ));
                 }
                 map.insert(
                     (key[0].clone(), key[1].clone()),
@@ -309,16 +313,12 @@ impl TimeSeriesData {
         for time in temporals_t {
             series.insert(time.clone(), 1.0);
         }
-        let time_series = TimeSeries {
-            scenario,
-            series,
-        };
+        let time_series = TimeSeries { scenario, series };
         TimeSeriesData {
             ts_data: vec![time_series],
         }
     }
 }
-
 
 // Implement a function to create the TimeSeries
 impl TimeSeries {
@@ -379,7 +379,6 @@ pub struct WeatherDataResponse {
     pub weather_values: Vec<f64>,
 }
 
-
 // Serialization function for DateTime<FixedOffset>
 fn serialize<S>(date: &DateTime<FixedOffset>, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -395,7 +394,8 @@ where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
-    s.parse::<DateTime<FixedOffset>>().map_err(serde::de::Error::custom)
+    s.parse::<DateTime<FixedOffset>>()
+        .map_err(serde::de::Error::custom)
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
-
-pub mod utilities;
-pub mod input_data;
+pub mod arrow_errors;
+pub mod arrow_input;
 pub mod errors;
 pub mod event_loop;
-pub mod arrow_input;
-pub mod arrow_errors;
+pub mod input_data;
+pub mod settings;
+pub mod utilities;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,29 +1,27 @@
-
-
-mod utilities;
-mod input_data;
+mod arrow_errors;
+mod arrow_input;
 mod errors;
 mod event_loop;
-mod arrow_input;
-mod arrow_errors;
+mod input_data;
+mod utilities;
 
-use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE, AUTHORIZATION};
-use serde_json::json;
-use serde_json;
+use chrono::{Duration as ChronoDuration, FixedOffset, Timelike, Utc};
+use input_data::{DataTable, InputData, OptimizationData};
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION, CONTENT_TYPE};
 use reqwest::Client;
+use serde_json;
+use serde_json::from_str;
+use serde_json::json;
 use std::collections::HashMap;
 use std::error::Error;
-use std::process::Command;
-use zmq;
-use std::process::ExitStatus;
-use std::io::Read;
 use std::fs::File;
-use serde_json::from_str;
+use std::io::Read;
+use std::process::Command;
+use std::process::ExitStatus;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Mutex};
 use warp::Filter;
-use chrono::{Timelike, FixedOffset, Utc, Duration as ChronoDuration};
-use input_data::{OptimizationData, InputData, DataTable};
+use zmq;
 
 //use std::time::{SystemTime, UNIX_EPOCH};
 //use tokio::join;
@@ -31,7 +29,7 @@ use input_data::{OptimizationData, InputData, DataTable};
 //use chrono::{Utc, Duration as ChronoDuration, TimeZone, Timelike};
 
 /// This function is used to make post request to Home Assistant in the Hertta development phase
-/// 
+///
 /// Sends a POST request to control light brightness.
 ///
 /// This asynchronous function sends a POST request to a given URL to control the brightness of a specified light entity.
@@ -51,17 +49,21 @@ use input_data::{OptimizationData, InputData, DataTable};
 /// - Errors in header construction or during the sending of the request are converted to `PostRequestError`.
 /// - Errors in the response status (e.g., non-successful HTTP status codes) are also converted to `PostRequestError`.
 ///
-async fn _make_post_request(url: &str, entity_id: &str, token: &str, brightness: f64) -> Result<(), errors::PostRequestError> {
-    
+async fn _make_post_request(
+    url: &str,
+    entity_id: &str,
+    token: &str,
+    brightness: f64,
+) -> Result<(), errors::PostRequestError> {
     // Check if the token is valid for HTTP headers
     if !utilities::_is_valid_http_header_value(token) {
         return Err(errors::PostRequestError("Invalid token header".to_string()));
     }
-    
+
     // Construct the request headers, including content type and authorization.
     let mut headers = HeaderMap::new();
     headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
-    
+
     // Handle the creation of the token header safely, converting any error into a `PostRequestError`.
     let token_header = HeaderValue::from_str(&format!("{}", token))
         .map_err(|e| errors::PostRequestError(format!("Invalid token header: {}", e)))?;
@@ -72,7 +74,7 @@ async fn _make_post_request(url: &str, entity_id: &str, token: &str, brightness:
         "entity_id": entity_id,
         "brightness": brightness,
     });
-    
+
     // Send the POST request using the constructed headers and payload.
     let client = Client::new();
     let response = client
@@ -92,25 +94,19 @@ async fn _make_post_request(url: &str, entity_id: &str, token: &str, brightness:
     Ok(())
 }
 
-
-
 pub fn start_hass_backend_server() {
-
     Command::new("python")
-    .arg("hass_backend/server.py") // Replace with the actual path to your Python file
-    .spawn() // Spawns the command as a new process, not blocking the current thread
-    .expect("HASS backend server failed to start");
-
+        .arg("hass_backend/server.py") // Replace with the actual path to your Python file
+        .spawn() // Spawns the command as a new process, not blocking the current thread
+        .expect("HASS backend server failed to start");
 }
 
 pub fn start_weather_forecast_server() {
-
     // Start Python server 2
     Command::new("python")
-    .arg("forecasts/weather_forecast.py") // Replace with the actual path to your Python file
-    .spawn() // Spawns the command as a new process, not blocking the current thread
-    .expect("Weather forecast failed to start");
-
+        .arg("forecasts/weather_forecast.py") // Replace with the actual path to your Python file
+        .spawn() // Spawns the command as a new process, not blocking the current thread
+        .expect("Weather forecast failed to start");
 }
 
 pub fn json_to_inputdata(json_file_path: &str) -> Result<input_data::InputData, Box<dyn Error>> {
@@ -123,7 +119,10 @@ pub fn json_to_inputdata(json_file_path: &str) -> Result<input_data::InputData, 
 }
 
 // Function to send serialized batches
-pub fn send_serialized_batches(serialized_batches: &HashMap<String, Vec<u8>>, zmq_context: &zmq::Context) -> Result<(), Box<dyn Error>> {
+pub fn send_serialized_batches(
+    serialized_batches: &HashMap<String, Vec<u8>>,
+    zmq_context: &zmq::Context,
+) -> Result<(), Box<dyn Error>> {
     let push_socket = zmq_context.socket(zmq::PUSH)?;
     push_socket.connect("tcp://127.0.0.1:5555")?;
 
@@ -140,7 +139,7 @@ pub fn find_available_port() -> u16 {
     listener.local_addr().unwrap().port()
 }
 
-/* 
+/*
 pub fn receive_data(endpoint: &str, zmq_context: &zmq::Context, data_store: &Arc<Mutex<Vec<DataTable>>>) -> Result<(), Box<dyn Error>> {
     let receiver = zmq_context.socket(zmq::PULL)?;
     receiver.connect(endpoint)?;
@@ -152,7 +151,7 @@ pub fn receive_data(endpoint: &str, zmq_context: &zmq::Context, data_store: &Arc
     for record_batch_result in reader {
         let record_batch = record_batch_result.expect("Failed to read record batch");
         let data_table = DataTable::from_record_batch(&record_batch);
-        
+
         let mut data_store = data_store.lock().unwrap();
         data_store.push(data_table);
     }
@@ -185,10 +184,14 @@ pub fn print_data_table(data_table: &DataTable) {
 
 pub fn create_time_data() -> input_data::TimeData {
     // Get the current time and round it to the latest hour
-    let start_time = Utc::now().with_timezone(&FixedOffset::east_opt(0).unwrap())
-                                .with_minute(0).unwrap()
-                                .with_second(0).unwrap()
-                                .with_nanosecond(0).unwrap();
+    let start_time = Utc::now()
+        .with_timezone(&FixedOffset::east_opt(0).unwrap())
+        .with_minute(0)
+        .unwrap()
+        .with_second(0)
+        .unwrap()
+        .with_nanosecond(0)
+        .unwrap();
     let end_time = start_time + ChronoDuration::hours(12);
 
     // Generate a series of timestamps every 60 minutes
@@ -206,11 +209,8 @@ pub fn create_time_data() -> input_data::TimeData {
     }
 }
 
-
 pub fn run_python_script() -> Result<(), Box<dyn Error>> {
-    let status = Command::new("python")
-        .arg("input_data.py")
-        .status()?;
+    let status = Command::new("python").arg("input_data.py").status()?;
 
     if status.success() {
         println!("Python script executed successfully.");
@@ -223,76 +223,77 @@ pub fn run_python_script() -> Result<(), Box<dyn Error>> {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-
     // Define a route with query parameters for optimization
     let optimize_route = warp::path("optimize")
         .and(warp::post())
         .and(warp::query::<HashMap<String, String>>())
         .and(warp::body::json())
-        .and_then(|params: HashMap<String, String>, input_data: InputData| async move {
-            let fetch_time_data = params.get("fetch_time_data").map_or(false, |v| v == "true");
-            let fetch_weather_data = params.get("fetch_weather_data").map_or(false, |v| v == "true");
-            let fetch_elec_data = params.get("fetch_elec_data").map_or(false, |v| v == "elering" || v == "entsoe");
-            let elec_price_source = params.get("fetch_elec_data").cloned();
-            let country = params.get("country").cloned();
-            let location = params.get("location").cloned();
+        .and_then(
+            |params: HashMap<String, String>, input_data: InputData| async move {
+                let fetch_time_data = params.get("fetch_time_data").map_or(false, |v| v == "true");
+                let fetch_weather_data = params
+                    .get("fetch_weather_data")
+                    .map_or(false, |v| v == "true");
+                let fetch_elec_data = params
+                    .get("fetch_elec_data")
+                    .map_or(false, |v| v == "elering" || v == "entsoe");
+                let elec_price_source = params.get("fetch_elec_data").cloned();
+                let country = params.get("country").cloned();
+                let location = params.get("location").cloned();
 
-            println!("Received optimization request with options:");
-            println!("Fetch time data: {}", fetch_time_data);
-            println!("Fetch weather data: {}", fetch_weather_data);
-            println!("Fetch electricity data: {}", fetch_elec_data);
-            println!("Electricity price source: {:?}", elec_price_source);
-            println!("Country: {:?}", country);
-            println!("Location: {:?}", location);
+                println!("Received optimization request with options:");
+                println!("Fetch time data: {}", fetch_time_data);
+                println!("Fetch weather data: {}", fetch_weather_data);
+                println!("Fetch electricity data: {}", fetch_elec_data);
+                println!("Electricity price source: {:?}", elec_price_source);
+                println!("Country: {:?}", country);
+                println!("Location: {:?}", location);
 
-            // Create OptimizationData instance
-            let optimization_data = OptimizationData {
-                fetch_weather_data,
-                fetch_elec_data,
-                fetch_time_data,
-                country,
-                location,
-                timezone: None,
-                elec_price_source: None,
-                model_data: Some(input_data),
-                time_data: None,
-                weather_data: None,
-                elec_price_data: None,
-                control_results: None,
-                input_data_batch: None,
-            };
+                // Create OptimizationData instance
+                let optimization_data = OptimizationData {
+                    fetch_weather_data,
+                    fetch_elec_data,
+                    fetch_time_data,
+                    country,
+                    location,
+                    timezone: None,
+                    elec_price_source: None,
+                    model_data: Some(input_data),
+                    time_data: None,
+                    weather_data: None,
+                    elec_price_data: None,
+                    control_results: None,
+                    input_data_batch: None,
+                };
 
-            //println!("Created OptimizationData: {:?}", optimization_data);
+                //println!("Created OptimizationData: {:?}", optimization_data);
 
-            let (tx, rx) = mpsc::channel::<OptimizationData>(32);
-            let tx = Arc::new(Mutex::new(tx));
+                let (tx, rx) = mpsc::channel::<OptimizationData>(32);
+                let tx = Arc::new(Mutex::new(tx));
 
-            tokio::spawn(async move {
-                event_loop::event_loop(rx).await;
-            });
+                tokio::spawn(async move {
+                    event_loop::event_loop(rx).await;
+                });
 
-            let tx_clone = Arc::clone(&tx);
-            tokio::spawn(async move {
-                let optimization_data = optimization_data.clone(); // Cloning the data to avoid ownership issues
-                let tx = tx_clone.lock().await;
-                if tx.send(optimization_data).await.is_err() {
-                    eprintln!("Failed to send optimization data");
-                }
-            });
+                let tx_clone = Arc::clone(&tx);
+                tokio::spawn(async move {
+                    let optimization_data = optimization_data.clone(); // Cloning the data to avoid ownership issues
+                    let tx = tx_clone.lock().await;
+                    if tx.send(optimization_data).await.is_err() {
+                        eprintln!("Failed to send optimization data");
+                    }
+                });
 
-            // Return a response
-            Ok::<_, warp::Rejection>(warp::reply::json(&"Optimization started"))
-        });
+                // Return a response
+                Ok::<_, warp::Rejection>(warp::reply::json(&"Optimization started"))
+            },
+        );
 
     // Combine the routes
     let routes = warp::path("api").and(optimize_route);
 
     // Start the server
-    warp::serve(routes)
-        .run(([127, 0, 0, 1], 3030))
-        .await;
+    warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
 
     Ok(())
-    
 }
-

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,143 @@
+use config::builder::{ConfigBuilder, DefaultState};
+use config::{Config, ConfigError};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::env;
+use std::path::PathBuf;
+
+const JULIA_EXEC_FIELD: &str = "julia_exec";
+const JULIA_PROJECT_FIELD: &str = "julia_project";
+
+#[derive(Serialize, Deserialize)]
+pub struct Settings {
+    pub julia_exec: Option<String>,
+    pub julia_project: String,
+}
+
+pub fn make_settings_file_path() -> PathBuf {
+    directories::ProjectDirs::from("", "", "Hertta")
+        .expect("system should have a home directory")
+        .preference_dir()
+        .join("settings.toml")
+}
+
+fn make_config_builder(
+    environment_variables: &HashMap<String, String>,
+) -> ConfigBuilder<DefaultState> {
+    let config = Config::builder()
+        .set_default(JULIA_PROJECT_FIELD, "@")
+        .expect("key should be convertible to string");
+    let julia_exec_from_path = environment_variables
+        .get("PATH")
+        .and_then(|paths| julia_exec_from(&paths).and_then(|path| path.to_str().map(String::from)));
+    config
+        .set_default(JULIA_EXEC_FIELD, julia_exec_from_path)
+        .expect("key should be convertible to string")
+}
+
+pub fn make_settings(
+    environment_variables: &HashMap<String, String>,
+    settings_file_path: &PathBuf,
+) -> Result<Settings, ConfigError> {
+    let builder = make_config_builder(environment_variables);
+    let builder = builder.add_source(
+        config::File::new(
+            settings_file_path
+                .to_str()
+                .expect("file path should be convertible to string"),
+            config::FileFormat::Toml,
+        )
+        .required(false),
+    );
+    let config = builder.build()?;
+    config.try_deserialize::<Settings>()
+}
+
+fn julia_exec_from(path_variable: &str) -> Option<PathBuf> {
+    for path in env::split_paths(&path_variable) {
+        let mut path = path.join("julia");
+        path.set_extension(env::consts::EXE_EXTENSION);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+    use std::fs::File;
+    use std::path::Path;
+    use tempfile::{tempdir, TempDir};
+
+    #[test]
+    fn settings_file_name_is_correct() {
+        let path = make_settings_file_path();
+        assert_eq!(path.file_name(), Some(OsStr::new("settings.toml")));
+    }
+
+    fn create_temporary_julia_exe() -> TempDir {
+        let temp_dir = tempdir().expect("temporary directory creation should be possible");
+        let julia_exec_path = julia_exec_path_from(&temp_dir);
+        File::create(&julia_exec_path).expect("file creation should succeed");
+        temp_dir
+    }
+
+    fn julia_exec_path_from(temp_dir: &TempDir) -> PathBuf {
+        let mut julia_exec_path = temp_dir.path().join("julia");
+        julia_exec_path.set_extension(env::consts::EXE_EXTENSION);
+        julia_exec_path
+    }
+
+    #[test]
+    fn julia_not_found_in_path_means_none() {
+        let path_string = env::join_paths([
+            Path::new("/julia/is/not/here"),
+            Path::new("/it/is/not/here/either"),
+        ])
+        .expect("paths should be joinable")
+        .into_string()
+        .expect("test PATH should be valid string");
+        assert!(julia_exec_from(&path_string).is_none());
+    }
+    #[test]
+    fn julia_found_in_path_when_its_executable_exists() {
+        let temp_julia_dir = create_temporary_julia_exe();
+        let path_string = env::join_paths([Path::new("/julia/is/not/here"), temp_julia_dir.path()])
+            .expect("paths should be joinable")
+            .into_string()
+            .expect("test PATH should be a valid string");
+        assert_eq!(
+            julia_exec_from(&path_string).expect("Julia should have been in PATH"),
+            julia_exec_path_from(&temp_julia_dir)
+        );
+    }
+    #[test]
+    fn default_settings_when_nothing_is_provided() {
+        let settings =
+            make_settings(&HashMap::new(), &PathBuf::new()).expect("settings should work fine");
+        assert_eq!(settings.julia_exec, None);
+        assert_eq!(settings.julia_project, "@");
+    }
+    #[test]
+    fn default_settings_when_julia_is_in_path() {
+        let temp_julia_dir = create_temporary_julia_exe();
+        let path_string = env::join_paths([temp_julia_dir.path()])
+            .expect("paths should be joinable")
+            .into_string()
+            .expect("test PATH should be a valid string");
+        let mut environment_variables = HashMap::<String, String>::new();
+        environment_variables.insert(String::from("PATH"), path_string);
+        let settings = make_settings(&environment_variables, &PathBuf::new())
+            .expect("settings should work fine");
+        assert_eq!(
+            settings.julia_exec,
+            julia_exec_path_from(&temp_julia_dir)
+                .to_str()
+                .map(String::from)
+        );
+        assert_eq!(settings.julia_project, "@");
+    }
+}

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -14,6 +14,14 @@ pub struct Settings {
     pub julia_project: String,
 }
 
+pub fn map_from_environment_variables() -> HashMap<String, String> {
+    let mut map = HashMap::<String, String>::new();
+    for (key, value) in env::vars() {
+        map.insert(key, value);
+    }
+    map
+}
+
 pub fn make_settings_file_path() -> PathBuf {
     directories::ProjectDirs::from("", "", "Hertta")
         .expect("system should have a home directory")

--- a/src/utilities.rs
+++ b/src/utilities.rs
@@ -1,9 +1,8 @@
 use crate::input_data;
 
+use arrow::array::{Array, ArrayRef, Float64Array, Int32Array, StringArray};
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use arrow::array::{Array, StringArray, Float64Array, Int32Array, ArrayRef};
-
 
 //POISTETTAVA
 
@@ -11,7 +10,8 @@ pub async fn _update_all_ts_data(optimization_data: Arc<Mutex<input_data::Optimi
     let mut data = optimization_data.lock().await;
     if let Some(ref mut model_data) = data.model_data {
         let temporals_t = &model_data.temporals.t;
-        let default_ts_data = input_data::TimeSeriesData::from_temporals(temporals_t, "default_scenario".to_string());
+        let default_ts_data =
+            input_data::TimeSeriesData::from_temporals(temporals_t, "default_scenario".to_string());
         println!("Default TS Data: {:?}", default_ts_data);
 
         for process in model_data.processes.values_mut() {
@@ -68,7 +68,6 @@ pub async fn _update_all_ts_data(optimization_data: Arc<Mutex<input_data::Optimi
     }
 }
 
-
 pub fn _column_value_to_string(column: &ArrayRef, row_index: usize) -> String {
     if column.is_null(row_index) {
         return "NULL".to_string();
@@ -115,7 +114,9 @@ pub fn check_series(ts_data: &input_data::TimeSeries, temporals_t: &[String], co
     }
 }
 
-pub async fn check_ts_data_against_temporals(optimization_data: Arc<Mutex<input_data::OptimizationData>>) {
+pub async fn check_ts_data_against_temporals(
+    optimization_data: Arc<Mutex<input_data::OptimizationData>>,
+) {
     let data = optimization_data.lock().await;
     if let Some(model_data) = &data.model_data {
         let temporals_t = &model_data.temporals.t;
@@ -145,7 +146,14 @@ pub async fn check_ts_data_against_temporals(optimization_data: Arc<Mutex<input_
 
         for node_diffusion in &model_data.node_diffusion {
             for ts_data in &node_diffusion.coefficient.ts_data {
-                check_series(&ts_data, temporals_t, &format!("diffusion {}-{}", node_diffusion.node1, node_diffusion.node2));
+                check_series(
+                    &ts_data,
+                    temporals_t,
+                    &format!(
+                        "diffusion {}-{}",
+                        node_diffusion.node1, node_diffusion.node2
+                    ),
+                );
             }
         }
 
@@ -191,7 +199,7 @@ pub fn _print_tuple_vector(v: &Vec<(String, f64)>) {
 /// # Arguments
 ///
 /// - `solution_vector`: A mutable reference to the vector that will store the combined tuples.
-///   This vector is cleared at the beginning of the function to ensure it only contains the 
+///   This vector is cleared at the beginning of the function to ensure it only contains the
 ///   combined results.
 /// - `vector1`: A vector of `String` elements, each representing the first element of the tuple.
 /// - `vector2`: A vector of `f64` elements, each representing the second element of the tuple.
@@ -200,16 +208,19 @@ pub fn _print_tuple_vector(v: &Vec<(String, f64)>) {
 ///
 /// Returns an `Err` with a string message if `vector1` and `vector2` have different lengths.
 ///
-pub fn _combine_vectors(vector1: Vec<String>, vector2: Vec<f64>) -> Result<Vec<(String, f64)>, String> {
+pub fn _combine_vectors(
+    vector1: Vec<String>,
+    vector2: Vec<f64>,
+) -> Result<Vec<(String, f64)>, String> {
     if vector1.len() != vector2.len() {
         return Err("Vectors have different lengths".to_string());
     }
 
-    let combined_vector: Vec<(String, f64)> = vector1.into_iter().zip(vector2.into_iter()).collect();
+    let combined_vector: Vec<(String, f64)> =
+        vector1.into_iter().zip(vector2.into_iter()).collect();
 
     Ok(combined_vector)
 }
-
 
 /// Checks if a string is a valid HTTP header value.
 ///
@@ -227,5 +238,3 @@ pub fn _combine_vectors(vector1: Vec<String>, vector2: Vec<f64>) -> Result<Vec<(
 pub fn _is_valid_http_header_value(value: &str) -> bool {
     value.is_ascii() && !value.chars().any(|ch| ch.is_control())
 }
-
-

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-/* 
+/*
 
 use hertta::weather_data::get_weather_data;
 


### PR DESCRIPTION
This PR adds settings to Hertta that allow specifying paths to system-specific things like Julia executable and the Julia project that the `Pr_ArrowConnection.jl` script uses.

The settings are stored in in `settings.toml` in current user's config directory. An empty settings file can be created with the `--write-settings` command line argument, e.g.

```shell
cargo run -- --write-setttings
```
