### PR TITLE
Rename many GraphQL mutation entry points

### DIFF
--- a/src/graphql/con_factor_input.rs
+++ b/src/graphql/con_factor_input.rs
@@ -1,7 +1,7 @@
 use super::{ValidationError, ValidationErrors};
 use crate::input_data_base::{BaseConFactor, BaseGenConstraint, BaseNode, BaseProcess, VariableId};
 
-pub fn add_flow_con_factor(
+pub fn create_flow_con_factor(
     factor: f64,
     constraint_name: String,
     process_name: String,
@@ -13,7 +13,7 @@ pub fn add_flow_con_factor(
         Ok(constraint) => constraint,
         Err(errors) => return errors,
     };
-    let errors = validate_flow_con_factor_to_add(
+    let errors = validate_flow_con_factor_creation(
         &process_name,
         &source_or_sink_node_name,
         constraint,
@@ -50,7 +50,7 @@ fn find_constraint<'a>(
     Ok(constraint)
 }
 
-fn validate_flow_con_factor_to_add(
+fn validate_flow_con_factor_creation(
     process: &String,
     source_or_sink_node: &String,
     constraint: &BaseGenConstraint,
@@ -99,7 +99,7 @@ fn validate_flow_con_factor_to_add(
     errors
 }
 
-pub fn add_state_con_factor(
+pub fn create_state_con_factor(
     factor: f64,
     constraint_name: String,
     node_name: String,
@@ -110,7 +110,7 @@ pub fn add_state_con_factor(
         Ok(constraint) => constraint,
         Err(errors) => return errors,
     };
-    let errors = validate_state_con_factor_to_add(&node_name, constraint, nodes);
+    let errors = validate_state_con_factor_creation(&node_name, constraint, nodes);
     if !errors.is_empty() {
         return ValidationErrors::from(errors);
     }
@@ -126,7 +126,7 @@ pub fn add_state_con_factor(
     ValidationErrors::default()
 }
 
-fn validate_state_con_factor_to_add(
+fn validate_state_con_factor_creation(
     node: &String,
     constraint: &BaseGenConstraint,
     nodes: &Vec<BaseNode>,
@@ -152,7 +152,7 @@ fn validate_state_con_factor_to_add(
     errors
 }
 
-pub fn add_online_con_factor(
+pub fn create_online_con_factor(
     factor: f64,
     constraint_name: String,
     process_name: String,
@@ -163,7 +163,7 @@ pub fn add_online_con_factor(
         Ok(constraint) => constraint,
         Err(errors) => return errors,
     };
-    let errors = validate_online_con_factor_to_add(&process_name, constraint, processes);
+    let errors = validate_online_con_factor_creation(&process_name, constraint, processes);
     if !errors.is_empty() {
         return ValidationErrors::from(errors);
     }
@@ -179,7 +179,7 @@ pub fn add_online_con_factor(
     ValidationErrors::default()
 }
 
-fn validate_online_con_factor_to_add(
+fn validate_online_con_factor_creation(
     process: &String,
     constraint: &BaseGenConstraint,
     processes: &Vec<BaseProcess>,

--- a/src/graphql/gen_constraint_input.rs
+++ b/src/graphql/gen_constraint_input.rs
@@ -3,7 +3,7 @@ use crate::input_data_base::BaseGenConstraint;
 use juniper::GraphQLInputObject;
 
 #[derive(GraphQLInputObject)]
-pub struct AddGenConstraintInput {
+pub struct NewGenConstraint {
     name: String,
     gc_type: String,
     is_setpoint: bool,
@@ -11,7 +11,7 @@ pub struct AddGenConstraintInput {
     constant: Option<f64>,
 }
 
-impl AddGenConstraintInput {
+impl NewGenConstraint {
     fn to_gen_constraint(self) -> BaseGenConstraint {
         BaseGenConstraint {
             name: self.name,
@@ -24,11 +24,11 @@ impl AddGenConstraintInput {
     }
 }
 
-pub fn add_gen_constraint(
-    constraint: AddGenConstraintInput,
+pub fn create_gen_constraint(
+    constraint: NewGenConstraint,
     constraints: &mut Vec<BaseGenConstraint>,
 ) -> ValidationErrors {
-    let errors = validate_gen_contraint_to_add(&constraint, constraints);
+    let errors = validate_gen_contraint_creation(&constraint, constraints);
     if !errors.is_empty() {
         return ValidationErrors::from(errors);
     }
@@ -36,8 +36,8 @@ pub fn add_gen_constraint(
     ValidationErrors::default()
 }
 
-fn validate_gen_contraint_to_add(
-    constraint: &AddGenConstraintInput,
+fn validate_gen_contraint_creation(
+    constraint: &NewGenConstraint,
     constraints: &Vec<BaseGenConstraint>,
 ) -> Vec<ValidationError> {
     let mut errors = Vec::new();

--- a/src/graphql/group_input.rs
+++ b/src/graphql/group_input.rs
@@ -2,15 +2,15 @@ use super::MaybeError;
 use crate::input_data::{Group, GroupType, Name};
 use crate::input_data_base::GroupMember;
 
-pub fn add_node_group(name: String, groups: &mut Vec<Group>) -> MaybeError {
-    add_group(name, GroupType::Node, groups)
+pub fn create_node_group(name: String, groups: &mut Vec<Group>) -> MaybeError {
+    create_group(name, GroupType::Node, groups)
 }
 
-pub fn add_process_group(name: String, groups: &mut Vec<Group>) -> MaybeError {
-    add_group(name, GroupType::Process, groups)
+pub fn create_process_group(name: String, groups: &mut Vec<Group>) -> MaybeError {
+    create_group(name, GroupType::Process, groups)
 }
 
-fn add_group(name: String, group_type: GroupType, groups: &mut Vec<Group>) -> MaybeError {
+fn create_group(name: String, group_type: GroupType, groups: &mut Vec<Group>) -> MaybeError {
     let maybe_error = validate_name(&name, &groups);
     if maybe_error.error.is_some() {
         return maybe_error;

--- a/src/graphql/input_data_setup_input.rs
+++ b/src/graphql/input_data_setup_input.rs
@@ -4,7 +4,7 @@ use juniper::GraphQLInputObject;
 use super::ValidationErrors;
 
 #[derive(GraphQLInputObject)]
-pub struct InputDataSetupInput {
+pub struct InputDataSetupUpdate {
     contains_reserves: Option<bool>,
     contains_online: Option<bool>,
     contains_states: Option<bool>,
@@ -23,7 +23,7 @@ pub struct InputDataSetupInput {
     ramp_dummy_variable_cost: Option<f64>,
 }
 
-impl InputDataSetupInput {
+impl InputDataSetupUpdate {
     fn update_input_data_setup(self, setup: &mut BaseInputDataSetup) {
         if let Some(flag) = self.contains_reserves {
             setup.contains_reserves = flag;
@@ -77,7 +77,7 @@ impl InputDataSetupInput {
 }
 
 pub fn update_input_data_setup(
-    setup_update: InputDataSetupInput,
+    setup_update: InputDataSetupUpdate,
     setup: &mut BaseInputDataSetup,
 ) -> ValidationErrors {
     setup_update.update_input_data_setup(setup);

--- a/src/graphql/market_input.rs
+++ b/src/graphql/market_input.rs
@@ -4,7 +4,7 @@ use crate::input_data_base::{BaseMarket, BaseNode, BaseProcess, GroupMember};
 use juniper::GraphQLInputObject;
 
 #[derive(GraphQLInputObject)]
-pub struct AddMarketInput {
+pub struct NewMarket {
     name: String,
     m_type: String,
     node: String,
@@ -23,7 +23,7 @@ pub struct AddMarketInput {
     reserve_activation_price: Option<f64>,
 }
 
-impl AddMarketInput {
+impl NewMarket {
     fn to_market(self) -> BaseMarket {
         BaseMarket {
             name: self.name,
@@ -53,13 +53,13 @@ impl AddMarketInput {
     }
 }
 
-pub fn add_market(
-    market: AddMarketInput,
+pub fn create_market(
+    market: NewMarket,
     markets: &mut Vec<BaseMarket>,
     nodes: &Vec<BaseNode>,
     groups: &Vec<Group>,
 ) -> ValidationErrors {
-    let errors = validate_market_to_add(&market, nodes, groups);
+    let errors = validate_market_creation(&market, nodes, groups);
     if !errors.is_empty() {
         return ValidationErrors::from(errors);
     }
@@ -67,8 +67,8 @@ pub fn add_market(
     ValidationErrors::default()
 }
 
-fn validate_market_to_add(
-    market: &AddMarketInput,
+fn validate_market_creation(
+    market: &NewMarket,
     nodes: &Vec<BaseNode>,
     groups: &Vec<Group>,
 ) -> Vec<ValidationError> {

--- a/src/graphql/node_diffusion_input.rs
+++ b/src/graphql/node_diffusion_input.rs
@@ -9,14 +9,14 @@ fn to_node_diffusion(from_node: String, to_node: String, coefficient: f64) -> Ba
     }
 }
 
-pub fn add_node_diffusion(
+pub fn create_node_diffusion(
     from_node: String,
     to_node: String,
     coefficient: f64,
     diffusions: &mut Vec<BaseNodeDiffusion>,
     nodes: &Vec<BaseNode>,
 ) -> ValidationErrors {
-    let errors = validate_node_diffusion(&from_node, &to_node, diffusions, nodes);
+    let errors = validate_node_diffusion_creation(&from_node, &to_node, diffusions, nodes);
     if !errors.is_empty() {
         return ValidationErrors::from(errors);
     }
@@ -24,7 +24,7 @@ pub fn add_node_diffusion(
     ValidationErrors::default()
 }
 
-fn validate_node_diffusion(
+fn validate_node_diffusion_creation(
     from_node: &String,
     to_node: &String,
     diffusions: &Vec<BaseNodeDiffusion>,

--- a/src/graphql/node_input.rs
+++ b/src/graphql/node_input.rs
@@ -3,7 +3,7 @@ use crate::input_data_base::{BaseNode, BaseProcess};
 use juniper::GraphQLInputObject;
 
 #[derive(GraphQLInputObject)]
-pub struct AddNodeInput {
+pub struct NewNode {
     name: String,
     is_commodity: bool,
     is_market: bool,
@@ -12,7 +12,7 @@ pub struct AddNodeInput {
     inflow: Option<f64>,
 }
 
-impl AddNodeInput {
+impl NewNode {
     fn to_node(self) -> BaseNode {
         BaseNode {
             name: self.name,
@@ -28,7 +28,7 @@ impl AddNodeInput {
 }
 
 #[derive(GraphQLInputObject)]
-pub struct NodeInput {
+pub struct NodeUpdate {
     name: Option<String>,
     is_commodity: Option<bool>,
     is_market: Option<bool>,
@@ -39,12 +39,12 @@ pub struct NodeInput {
     inflow: Option<f64>,
 }
 
-pub fn add_node(
-    node: AddNodeInput,
+pub fn create_node(
+    node: NewNode,
     nodes: &mut Vec<BaseNode>,
     processes: &mut Vec<BaseProcess>,
 ) -> ValidationErrors {
-    let errors = validate_node_to_add(&node, nodes, processes);
+    let errors = validate_node_creation(&node, nodes, processes);
     if !errors.is_empty() {
         return ValidationErrors::from(errors);
     }
@@ -52,8 +52,8 @@ pub fn add_node(
     ValidationErrors::default()
 }
 
-fn validate_node_to_add(
-    node: &AddNodeInput,
+fn validate_node_creation(
+    node: &NewNode,
     nodes: &Vec<BaseNode>,
     processes: &Vec<BaseProcess>,
 ) -> Vec<ValidationError> {

--- a/src/graphql/process_input.rs
+++ b/src/graphql/process_input.rs
@@ -3,7 +3,7 @@ use crate::input_data_base::{BaseNode, BaseProcess};
 use juniper::GraphQLInputObject;
 
 #[derive(GraphQLInputObject)]
-pub struct AddProcessInput {
+pub struct NewProcess {
     name: String,
     #[graphql(description = "Must be 'unit' or 'transport'.")]
     conversion: String,
@@ -24,7 +24,7 @@ pub struct AddProcessInput {
     eff_ts: Option<f64>,
 }
 
-impl AddProcessInput {
+impl NewProcess {
     fn to_process(self) -> BaseProcess {
         BaseProcess {
             name: self.name,
@@ -53,12 +53,12 @@ impl AddProcessInput {
     }
 }
 
-pub fn add_process(
-    process: AddProcessInput,
+pub fn create_process(
+    process: NewProcess,
     processes: &mut Vec<BaseProcess>,
     nodes: &mut Vec<BaseNode>,
 ) -> ValidationErrors {
-    let errors = validate_process_to_add(&process, processes, nodes);
+    let errors = validate_process_creation(&process, processes, nodes);
     if !errors.is_empty() {
         return ValidationErrors::from(errors);
     }
@@ -66,8 +66,8 @@ pub fn add_process(
     ValidationErrors::default()
 }
 
-fn validate_process_to_add(
-    process: &AddProcessInput,
+fn validate_process_creation(
+    process: &NewProcess,
     processes: &Vec<BaseProcess>,
     nodes: &Vec<BaseNode>,
 ) -> Vec<ValidationError> {

--- a/src/graphql/risk_input.rs
+++ b/src/graphql/risk_input.rs
@@ -3,12 +3,12 @@ use crate::input_data_base::Risk;
 use juniper::GraphQLInputObject;
 
 #[derive(GraphQLInputObject)]
-pub struct AddRiskInput {
+pub struct NewRisk {
     parameter: String,
     value: f64,
 }
 
-impl AddRiskInput {
+impl NewRisk {
     fn to_risk(self) -> Risk {
         Risk {
             parameter: self.parameter,
@@ -17,8 +17,8 @@ impl AddRiskInput {
     }
 }
 
-pub fn add_risk(risk: AddRiskInput, risks: &mut Vec<Risk>) -> ValidationErrors {
-    let errors = validate_risk_to_add(&risk);
+pub fn create_risk(risk: NewRisk, risks: &mut Vec<Risk>) -> ValidationErrors {
+    let errors = validate_risk_creation(&risk);
     if !errors.is_empty() {
         return ValidationErrors::from(errors);
     }
@@ -26,7 +26,7 @@ pub fn add_risk(risk: AddRiskInput, risks: &mut Vec<Risk>) -> ValidationErrors {
     ValidationErrors::default()
 }
 
-fn validate_risk_to_add(risk: &AddRiskInput) -> Vec<ValidationError> {
+fn validate_risk_creation(risk: &NewRisk) -> Vec<ValidationError> {
     let mut errors = Vec::new();
     if risk.parameter.is_empty() {
         errors.push(ValidationError::new("parameter", "parameter is empty"));

--- a/src/graphql/scenario_input.rs
+++ b/src/graphql/scenario_input.rs
@@ -1,7 +1,7 @@
 use super::MaybeError;
 use crate::scenarios::Scenario;
 
-pub fn add_scenario(name: String, weight: f64, scenarios: &mut Vec<Scenario>) -> MaybeError {
+pub fn create_scenario(name: String, weight: f64, scenarios: &mut Vec<Scenario>) -> MaybeError {
     if scenarios.iter().find(|s| *s.name() == name).is_some() {
         return "a scenario with the same name exists".into();
     }

--- a/src/graphql/state_input.rs
+++ b/src/graphql/state_input.rs
@@ -6,7 +6,7 @@ use crate::input_data_base::BaseNode;
 use juniper::GraphQLInputObject;
 
 #[derive(GraphQLInputObject)]
-pub struct SetStateInput {
+pub struct StateInput {
     in_max: f64,
     out_max: f64,
     state_loss_proportional: f64,
@@ -19,7 +19,7 @@ pub struct SetStateInput {
     residual_value: f64,
 }
 
-impl SetStateInput {
+impl StateInput {
     fn to_state(self) -> State {
         State {
             in_max: self.in_max,
@@ -38,7 +38,7 @@ impl SetStateInput {
 
 pub fn set_state_for_node(
     node_name: &str,
-    state: Option<SetStateInput>,
+    state: Option<StateInput>,
     nodes: &mut Vec<BaseNode>,
 ) -> ValidationErrors {
     if let Some(ref real_state) = state {
@@ -60,7 +60,7 @@ pub fn set_state_for_node(
     ValidationErrors::from(Vec::new())
 }
 
-fn validate_state_to_set(state: &SetStateInput) -> Vec<ValidationError> {
+fn validate_state_to_set(state: &StateInput) -> Vec<ValidationError> {
     let mut errors = Vec::new();
     validate_state_min(state.state_min, state.state_max, &mut errors);
     validate_state_loss_proportional(state.state_loss_proportional, &mut errors);
@@ -83,7 +83,7 @@ fn validate_state_loss_proportional(state_loss: f64, errors: &mut Vec<Validation
 }
 
 #[derive(GraphQLInputObject)]
-pub struct UpdateStateInput {
+pub struct StateUpdate {
     in_max: Option<f64>,
     out_max: Option<f64>,
     state_loss_proportional: Option<f64>,
@@ -96,7 +96,7 @@ pub struct UpdateStateInput {
     residual_value: Option<f64>,
 }
 
-impl UpdateStateInput {
+impl StateUpdate {
     fn update_state(self, state: &mut State) {
         optional_update(self.in_max, &mut state.in_max);
         optional_update(self.out_max, &mut state.out_max);
@@ -124,7 +124,7 @@ fn optional_update<T>(source: Option<T>, target: &mut T) {
 }
 
 pub fn update_state_in_node(
-    state: UpdateStateInput,
+    state: StateUpdate,
     node_name: String,
     nodes: &mut Vec<BaseNode>,
 ) -> ValidationErrors {
@@ -149,10 +149,7 @@ pub fn update_state_in_node(
     ValidationErrors::default()
 }
 
-fn validate_state_to_update(
-    state_update: &UpdateStateInput,
-    state: &State,
-) -> Vec<ValidationError> {
+fn validate_state_to_update(state_update: &StateUpdate, state: &State) -> Vec<ValidationError> {
     let mut errors = Vec::new();
     if state_update.state_min.is_some() || state_update.state_max.is_some() {
         let min = state_update.state_min.unwrap_or(state.state_min);

--- a/src/graphql/time_line_input.rs
+++ b/src/graphql/time_line_input.rs
@@ -10,13 +10,13 @@ struct DurationInput {
 }
 
 #[derive(GraphQLInputObject)]
-pub struct TimeLineInput {
+pub struct TimeLineUpdate {
     duration: Option<DurationInput>,
     step: Option<DurationInput>,
 }
 
 pub fn update_time_line(
-    input: TimeLineInput,
+    input: TimeLineUpdate,
     time_line: &mut TimeLineSettings,
 ) -> ValidationErrors {
     let mut errors = Vec::new();
@@ -60,7 +60,7 @@ mod tests {
     #[test]
     fn update_time_line_works() {
         let mut time_line_settings = TimeLineSettings::default();
-        let input = TimeLineInput {
+        let input = TimeLineUpdate {
             duration: Some(DurationInput {
                 hours: 13,
                 minutes: 0,
@@ -87,7 +87,7 @@ mod tests {
     #[test]
     fn setting_negative_duration_causes_error() {
         let mut time_line_settings = TimeLineSettings::default();
-        let input = TimeLineInput {
+        let input = TimeLineUpdate {
             duration: Some(DurationInput {
                 hours: -13,
                 minutes: 0,
@@ -113,7 +113,7 @@ mod tests {
     #[test]
     fn setting_negative_step_causes_error() {
         let mut time_line_settings = TimeLineSettings::default();
-        let input = TimeLineInput {
+        let input = TimeLineUpdate {
             duration: Some(DurationInput {
                 hours: 13,
                 minutes: 0,
@@ -138,7 +138,7 @@ mod tests {
     #[test]
     fn setting_step_longer_than_duration_causes_error() {
         let mut time_line_settings = TimeLineSettings::default();
-        let input = TimeLineInput {
+        let input = TimeLineUpdate {
             duration: Some(DurationInput {
                 hours: 13,
                 minutes: 0,

--- a/src/graphql/topology_input.rs
+++ b/src/graphql/topology_input.rs
@@ -3,7 +3,7 @@ use crate::input_data_base::{BaseNode, BaseProcess, BaseTopology};
 use juniper::GraphQLInputObject;
 
 #[derive(GraphQLInputObject)]
-pub struct AddTopologyInput {
+pub struct NewTopology {
     pub capacity: f64,
     pub vom_cost: f64,
     pub ramp_up: f64,
@@ -13,7 +13,7 @@ pub struct AddTopologyInput {
     pub cap_ts: Option<f64>,
 }
 
-impl AddTopologyInput {
+impl NewTopology {
     fn to_topology(self, source: String, sink: String) -> BaseTopology {
         BaseTopology {
             source: source,
@@ -29,11 +29,11 @@ impl AddTopologyInput {
     }
 }
 
-pub fn add_topology_to_process(
+pub fn create_topology(
     process_name: String,
     source_node_name: Option<String>,
     sink_node_name: Option<String>,
-    topology: AddTopologyInput,
+    topology: NewTopology,
     processes: &mut Vec<BaseProcess>,
     nodes: &mut Vec<BaseNode>,
 ) -> ValidationErrors {
@@ -46,7 +46,7 @@ pub fn add_topology_to_process(
             )]);
         }
     };
-    let errors = validate_topology_to_add(
+    let errors = validate_topology_creation(
         &topology,
         &source_node_name,
         &sink_node_name,
@@ -62,8 +62,8 @@ pub fn add_topology_to_process(
     ValidationErrors::default()
 }
 
-fn validate_topology_to_add(
-    topology: &AddTopologyInput,
+fn validate_topology_creation(
+    topology: &NewTopology,
     source_node: &Option<String>,
     sink_node: &Option<String>,
     process: &BaseProcess,


### PR DESCRIPTION
This PR replaces the add prefix by create in many GraphQL mutations. This makes the mutations distinct from addNodeToGroup and addProcessToGroup which do not create new structures in input data.