### PR TITLE
Add GraphQL mutations that delete model items

### DIFF
--- a/src/graphql/delete.rs
+++ b/src/graphql/delete.rs
@@ -1,0 +1,12 @@
+use super::MaybeError;
+use crate::input_data::Name;
+use crate::input_data_base::TypeName;
+
+pub fn delete_named<T: Name + TypeName>(name: &str, items: &mut Vec<T>) -> MaybeError {
+    let position = match items.iter().position(|i| i.name() == name) {
+        Some(position) => position,
+        None => return format!("no such {}", T::type_name()).into(),
+    };
+    items.swap_remove(position);
+    MaybeError::new_ok()
+}

--- a/src/graphql/gen_constraint_input.rs
+++ b/src/graphql/gen_constraint_input.rs
@@ -1,4 +1,5 @@
-use super::{ValidationError, ValidationErrors};
+use super::delete;
+use super::{MaybeError, ValidationError, ValidationErrors};
 use crate::input_data_base::{BaseGenConstraint, ConstraintType};
 use juniper::GraphQLInputObject;
 
@@ -55,4 +56,8 @@ fn validate_gen_contraint_creation(
         ));
     }
     errors
+}
+
+pub fn delete_gen_constraint(name: &str, constraints: &mut Vec<BaseGenConstraint>) -> MaybeError {
+    delete::delete_named(name, constraints)
 }

--- a/src/graphql/group_input.rs
+++ b/src/graphql/group_input.rs
@@ -1,35 +1,54 @@
 use super::MaybeError;
 use crate::input_data::Name;
-use crate::input_data_base::{GroupMember, Members, NamedGroup, NodeGroup, ProcessGroup};
+use crate::input_data_base::{GroupMember, Members, NamedGroup, NodeGroup, ProcessGroup, TypeName};
 
-pub fn create_node_group(name: String, groups: &mut Vec<NodeGroup>) -> MaybeError {
-    create_group(name, groups)
+pub fn create_node_group(
+    name: String,
+    node_groups: &mut Vec<NodeGroup>,
+    process_groups: &Vec<ProcessGroup>,
+) -> MaybeError {
+    create_group(name, node_groups, process_groups)
 }
 
-pub fn create_process_group(name: String, groups: &mut Vec<ProcessGroup>) -> MaybeError {
-    create_group(name, groups)
+pub fn create_process_group(
+    name: String,
+    process_groups: &mut Vec<ProcessGroup>,
+    node_groups: &Vec<NodeGroup>,
+) -> MaybeError {
+    create_group(name, process_groups, node_groups)
 }
 
-fn create_group<T: Name + NamedGroup>(name: String, groups: &mut Vec<T>) -> MaybeError {
-    let maybe_error = validate_name(&name, &groups);
-    if maybe_error.error.is_some() {
+fn create_group<G: Name + NamedGroup + TypeName, H: Name + NamedGroup + TypeName>(
+    name: String,
+    target_groups: &mut Vec<G>,
+    other_groups: &Vec<H>,
+) -> MaybeError {
+    let maybe_error = validate_name(&name, target_groups, other_groups);
+    if maybe_error.message.is_some() {
         return maybe_error;
     }
-    groups.push(T::new(name));
+    target_groups.push(G::new(name));
     MaybeError::new_ok()
 }
 
-fn validate_name<T: Name>(name: &String, groups: &Vec<T>) -> MaybeError {
+fn validate_name<G: Name + TypeName, H: Name + TypeName>(
+    name: &String,
+    groups: &Vec<G>,
+    other_groups: &Vec<H>,
+) -> MaybeError {
     if name.is_empty() {
         return "name is empty".into();
     }
     if groups.iter().find(|&g| *g.name() == *name).is_some() {
-        return "a group with the same name exists".into();
+        return format!("a {} with the same name exists", G::type_name()).into();
+    }
+    if other_groups.iter().find(|&g| *g.name() == *name).is_some() {
+        return format!("a {} with the same name exists", H::type_name()).into();
     }
     MaybeError::new_ok()
 }
 
-pub fn add_to_group<M: GroupMember + Name, G: Members + Name>(
+pub fn add_to_group<M: GroupMember + Name + TypeName, G: Members + Name>(
     item_name: &str,
     group_name: &str,
     items: &mut Vec<M>,
@@ -37,10 +56,10 @@ pub fn add_to_group<M: GroupMember + Name, G: Members + Name>(
 ) -> MaybeError {
     let item = match items.iter_mut().find(|n| n.name() == item_name) {
         Some(node) => node,
-        None => return format!("no such {}", M::group_type()).into(),
+        None => return format!("no such {}", M::type_name()).into(),
     };
     if item.groups().iter().find(|&g| *g == group_name).is_some() {
-        return format!("{} is in the group already", M::group_type()).into();
+        return format!("{} is in the group already", M::type_name()).into();
     }
     let group = match groups.iter_mut().find(|g| g.name() == group_name) {
         Some(group) => group,
@@ -49,6 +68,24 @@ pub fn add_to_group<M: GroupMember + Name, G: Members + Name>(
     item.groups_mut().push(group_name.into());
     group.members_mut().push(item_name.into());
     MaybeError::new_ok()
+}
+
+pub fn delete_group(
+    name: &str,
+    node_groups: &mut Vec<NodeGroup>,
+    process_groups: &mut Vec<ProcessGroup>,
+) -> MaybeError {
+    if let Some(group_position) = node_groups.iter().position(|g| g.name() == name) {
+        node_groups.swap_remove(group_position);
+        return MaybeError::new_ok();
+    } else {
+        let group_position = match process_groups.iter().position(|g| g.name() == name) {
+            Some(position) => position,
+            None => return "no such group".into(),
+        };
+        process_groups.swap_remove(group_position);
+        return MaybeError::new_ok();
+    }
 }
 
 #[cfg(test)]
@@ -60,10 +97,62 @@ mod tests {
         let mut items = vec![BaseNode::new("my node".into())];
         let mut groups = vec![NodeGroup::new("nodes".into())];
         let maybe_error = add_to_group("my node", "nodes", &mut items, &mut groups);
-        assert!(maybe_error.error.is_none());
+        assert!(maybe_error.message.is_none());
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].groups, vec![String::from("nodes")]);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].members, vec![String::from("my node")]);
+    }
+    #[test]
+    fn create_node_group_complains_when_name_clashes_with_process_group() {
+        let mut node_groups = Vec::new();
+        let process_groups = vec![ProcessGroup::new("my group".into())];
+        let maybe_error = create_node_group("my group".into(), &mut node_groups, &process_groups);
+        match maybe_error.message {
+            Some(error) => assert_eq!(error, "a process group with the same name exists"),
+            None => panic!("creating node group should not succeed"),
+        }
+    }
+    #[test]
+    fn create_process_group_complains_when_name_clashes_with_node_group() {
+        let mut process_groups = Vec::new();
+        let node_groups = vec![NodeGroup::new("my group".into())];
+        let maybe_error =
+            create_process_group("my group".into(), &mut process_groups, &node_groups);
+        match maybe_error.message {
+            Some(error) => assert_eq!(error, "a node group with the same name exists"),
+            None => panic!("creating process group should not succeed"),
+        }
+    }
+    #[test]
+    fn delete_node_group() {
+        let mut node_groups = vec![NodeGroup::new("my group".into())];
+        let mut process_groups = Vec::new();
+        let maybe_error = delete_group("my group", &mut node_groups, &mut process_groups);
+        if maybe_error.message.is_some() {
+            panic!("deleting group should succeed");
+        }
+        assert!(node_groups.is_empty())
+    }
+    #[test]
+    fn delete_process_group() {
+        let mut node_groups = Vec::new();
+        let mut process_groups = vec![ProcessGroup::new("my group".into())];
+        let maybe_error = delete_group("my group", &mut node_groups, &mut process_groups);
+        if maybe_error.message.is_some() {
+            panic!("deleting group should succeed");
+        }
+        assert!(process_groups.is_empty())
+    }
+    #[test]
+    fn delete_group_fails_with_non_existent_group() {
+        let mut node_groups = Vec::new();
+        let mut process_groups = Vec::new();
+        let maybe_error = delete_group("my group", &mut node_groups, &mut process_groups);
+        if let Some(error) = maybe_error.message {
+            assert_eq!(error, "no such group");
+        } else {
+            panic!("deleting non-existent group should not succeed");
+        }
     }
 }

--- a/src/graphql/market_input.rs
+++ b/src/graphql/market_input.rs
@@ -1,4 +1,5 @@
-use super::{ValidationError, ValidationErrors};
+use super::delete;
+use super::{MaybeError, ValidationError, ValidationErrors};
 use crate::input_data_base::{BaseMarket, BaseNode, MarketDirection, MarketType, ProcessGroup};
 use juniper::GraphQLInputObject;
 
@@ -91,4 +92,8 @@ fn validate_market_creation(
         errors.push(ValidationError::new("min_bid", "greater than max_bid"));
     }
     errors
+}
+
+pub fn delete_market(name: &str, markets: &mut Vec<BaseMarket>) -> MaybeError {
+    delete::delete_named(name, markets)
 }

--- a/src/graphql/node_diffusion_input.rs
+++ b/src/graphql/node_diffusion_input.rs
@@ -1,4 +1,4 @@
-use super::{ValidationError, ValidationErrors};
+use super::{MaybeError, ValidationError, ValidationErrors};
 use crate::input_data_base::{BaseNode, BaseNodeDiffusion};
 
 fn to_node_diffusion(from_node: String, to_node: String, coefficient: f64) -> BaseNodeDiffusion {
@@ -54,4 +54,20 @@ fn validate_node_diffusion_creation(
         ));
     }
     errors
+}
+
+pub fn delete_node_diffusion(
+    from_node: &str,
+    to_node: &str,
+    diffusions: &mut Vec<BaseNodeDiffusion>,
+) -> MaybeError {
+    if let Some(position) = diffusions
+        .iter()
+        .position(|d| d.from_node == from_node && d.to_node == to_node)
+    {
+        diffusions.swap_remove(position);
+        return MaybeError::new_ok();
+    } else {
+        return "no such node diffusion".into();
+    }
 }

--- a/src/graphql/risk_input.rs
+++ b/src/graphql/risk_input.rs
@@ -1,4 +1,5 @@
-use super::{ValidationError, ValidationErrors};
+use super::delete;
+use super::{MaybeError, ValidationError, ValidationErrors};
 use crate::input_data_base::Risk;
 use juniper::GraphQLInputObject;
 
@@ -32,4 +33,8 @@ fn validate_risk_creation(risk: &NewRisk) -> Vec<ValidationError> {
         errors.push(ValidationError::new("parameter", "parameter is empty"));
     }
     errors
+}
+
+pub fn delete_risk(parameter: &str, risks: &mut Vec<Risk>) -> MaybeError {
+    delete::delete_named(parameter, risks)
 }

--- a/src/graphql/scenario_input.rs
+++ b/src/graphql/scenario_input.rs
@@ -1,7 +1,11 @@
+use super::delete;
 use super::MaybeError;
 use crate::scenarios::Scenario;
 
 pub fn create_scenario(name: String, weight: f64, scenarios: &mut Vec<Scenario>) -> MaybeError {
+    if name.is_empty() {
+        return "name is empty".into();
+    }
     if scenarios.iter().find(|s| *s.name() == name).is_some() {
         return "a scenario with the same name exists".into();
     }
@@ -11,4 +15,8 @@ pub fn create_scenario(name: String, weight: f64, scenarios: &mut Vec<Scenario>)
     };
     scenarios.push(scenario);
     MaybeError::new_ok()
+}
+
+pub fn delete_scenario(name: &str, scenarios: &mut Vec<Scenario>) -> MaybeError {
+    delete::delete_named(name, scenarios)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex;
-use warp::Filter;
 use warp::cors;
+use warp::Filter;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -115,23 +115,24 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Create CORS configuration
     let cors = cors()
-    .allow_any_origin()
-    .allow_methods(vec!["POST", "GET"])
-    .allow_headers(vec!["content-type", "authorization"])
-    .build();
+        .allow_any_origin()
+        .allow_methods(vec!["POST", "GET"])
+        .allow_headers(vec!["content-type", "authorization"])
+        .build();
 
-    let graphql_route = warp::path("graphql").and(juniper_warp::make_graphql_filter(
-        schema,
-        warp::any()
-            .and(inject_clone(settings))
-            .and(inject_clone(job_store))
-            .and(inject_clone(model))
-            .and(inject_clone(job_sender))
-            .map(|settings_clone, job_store_clone, model_clone, job_sender| {
-                HerttaContext::new(settings_clone, job_store_clone, model_clone, job_sender)
-            }),
-    ))
-    .with(cors);
+    let graphql_route = warp::path("graphql")
+        .and(juniper_warp::make_graphql_filter(
+            schema,
+            warp::any()
+                .and(inject_clone(settings))
+                .and(inject_clone(job_store))
+                .and(inject_clone(model))
+                .and(inject_clone(job_sender))
+                .map(|settings_clone, job_store_clone, model_clone, job_sender| {
+                    HerttaContext::new(settings_clone, job_store_clone, model_clone, job_sender)
+                }),
+        ))
+        .with(cors);
     let server_handle = warp::serve(graphql_route).run(([127, 0, 0, 1], 3030));
     server_handle.await;
     Ok(())

--- a/src/scenarios.rs
+++ b/src/scenarios.rs
@@ -1,4 +1,5 @@
 use crate::input_data::Name;
+use crate::input_data_base::TypeName;
 use hertta_derive::Name;
 use juniper::GraphQLObject;
 use serde::{Deserialize, Serialize};
@@ -19,6 +20,12 @@ impl Default for Scenario {
             name: "S1".to_string(),
             weight: 1.0,
         }
+    }
+}
+
+impl TypeName for Scenario {
+    fn type_name() -> &'static str {
+        "scenario"
     }
 }
 


### PR DESCRIPTION
Individual model items such as nodes, processes and constraints can now be deleted using GraphQL mutations. Note, that the mutations hold data integrity: for example, deleting a node will delete corresponding delays, diffusions, inflows, topologies and so on.

**Breaking**: The `error` field in `MaybeError` was renamed to `message` to make the type consistent with `ValidationError`.

**Breaking**: `ConversionFactorType` was renamed to `ConstraintFactorType`.