### PR TITLE
GraphQL mutations to create node delays and histories

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -5,6 +5,7 @@ mod group_input;
 mod input_data_setup_input;
 mod job_status;
 mod market_input;
+mod node_delay_input;
 mod node_diffusion_input;
 mod node_input;
 mod process_input;
@@ -32,6 +33,7 @@ use juniper::{
     GraphQLUnion, Nullable, RootNode,
 };
 use market_input::NewMarket;
+use node_delay_input::NewNodeDelay;
 use node_input::NewNode;
 use process_input::NewProcess;
 use risk_input::NewRisk;
@@ -701,6 +703,16 @@ impl Mutation {
             &from_node,
             &to_node,
             &mut model.input_data.node_diffusion,
+        )
+    }
+
+    async fn create_node_delay(delay: NewNodeDelay, context: &HerttaContext) -> ValidationErrors {
+        let mut model_ref = context.model.lock().await;
+        let model = model_ref.deref_mut();
+        node_delay_input::create_node_delay(
+            delay,
+            &mut model.input_data.node_delay,
+            &model.input_data.nodes,
         )
     }
 

--- a/src/graphql/con_factor_input.rs
+++ b/src/graphql/con_factor_input.rs
@@ -66,11 +66,10 @@ fn validate_flow_con_factor_creation(
         ));
     }
     if let Some(process) = processes.iter().find(|p| p.name == *process) {
-        if process
+        if !process
             .topos
             .iter()
-            .find(|t| t.source == *source_or_sink_node || t.sink == *source_or_sink_node)
-            .is_none()
+            .any(|t| t.source == *source_or_sink_node || t.sink == *source_or_sink_node)
         {
             errors.push(ValidationError::new(
                 "source_or_sink_node_name",
@@ -80,19 +79,14 @@ fn validate_flow_con_factor_creation(
     } else {
         errors.push(ValidationError::new("process_name", "no such process"));
     }
-    if constraint
-        .factors
-        .iter()
-        .find(|f| {
-            f.var_type == ConstraintFactorType::Flow
-                && f.var_tuple.entity == *process
-                && f.var_tuple
-                    .identifier
-                    .as_ref()
-                    .is_some_and(|i| i == source_or_sink_node)
-        })
-        .is_some()
-    {
+    if constraint.factors.iter().any(|f| {
+        f.var_type == ConstraintFactorType::Flow
+            && f.var_tuple.entity == *process
+            && f.var_tuple
+                .identifier
+                .as_ref()
+                .is_some_and(|i| i == source_or_sink_node)
+    }) {
         errors.push(ValidationError::new(
             "constraint_name",
             "a flow constraint factor with same process and node exists",
@@ -137,14 +131,13 @@ fn validate_state_con_factor_creation(
     if node.is_empty() {
         errors.push(ValidationError::new("node_name", "name is empty"));
     }
-    if nodes.iter().find(|n| n.name == *node).is_none() {
+    if !nodes.iter().any(|n| n.name == *node) {
         errors.push(ValidationError::new("node_name", "no such node"));
     }
     if constraint
         .factors
         .iter()
-        .find(|f| f.var_type == ConstraintFactorType::State && f.var_tuple.entity == *node)
-        .is_some()
+        .any(|f| f.var_type == ConstraintFactorType::State && f.var_tuple.entity == *node)
     {
         errors.push(ValidationError::new(
             "constraint_name",
@@ -190,14 +183,13 @@ fn validate_online_con_factor_creation(
     if process.is_empty() {
         errors.push(ValidationError::new("process_name", "name is empty"));
     }
-    if processes.iter().find(|p| p.name == *process).is_none() {
+    if !processes.iter().any(|p| p.name == *process) {
         errors.push(ValidationError::new("process_name", "no such process"));
     }
     if constraint
         .factors
         .iter()
-        .find(|f| f.var_type == ConstraintFactorType::Online && f.var_tuple.entity == *process)
-        .is_some()
+        .any(|f| f.var_type == ConstraintFactorType::Online && f.var_tuple.entity == *process)
     {
         errors.push(ValidationError::new(
             "constraint_name",

--- a/src/graphql/gen_constraint_input.rs
+++ b/src/graphql/gen_constraint_input.rs
@@ -45,11 +45,7 @@ fn validate_gen_contraint_creation(
     if constraint.name.is_empty() {
         errors.push(ValidationError::new("name", "name is empty"));
     }
-    if constraints
-        .iter()
-        .find(|c| c.name == constraint.name)
-        .is_some()
-    {
+    if constraints.iter().any(|c| c.name == constraint.name) {
         errors.push(ValidationError::new(
             "name",
             "a constraint with the same name exists",

--- a/src/graphql/group_input.rs
+++ b/src/graphql/group_input.rs
@@ -39,10 +39,10 @@ fn validate_name<G: Name + TypeName, H: Name + TypeName>(
     if name.is_empty() {
         return "name is empty".into();
     }
-    if groups.iter().find(|&g| *g.name() == *name).is_some() {
+    if groups.iter().any(|g| *g.name() == *name) {
         return format!("a {} with the same name exists", G::type_name()).into();
     }
-    if other_groups.iter().find(|&g| *g.name() == *name).is_some() {
+    if other_groups.iter().any(|g| *g.name() == *name) {
         return format!("a {} with the same name exists", H::type_name()).into();
     }
     MaybeError::new_ok()
@@ -58,7 +58,7 @@ pub fn add_to_group<M: GroupMember + Name + TypeName, G: Members + Name>(
         Some(node) => node,
         None => return format!("no such {}", M::type_name()).into(),
     };
-    if item.groups().iter().find(|&g| *g == group_name).is_some() {
+    if item.groups().iter().any(|g| g == group_name) {
         return format!("{} is in the group already", M::type_name()).into();
     }
     let group = match groups.iter_mut().find(|g| g.name() == group_name) {

--- a/src/graphql/market_input.rs
+++ b/src/graphql/market_input.rs
@@ -70,14 +70,10 @@ fn validate_market_creation(
     if market.name.is_empty() {
         errors.push(ValidationError::new("name", "name is empty"));
     }
-    if nodes.iter().find(|n| n.name == market.node).is_none() {
+    if !nodes.iter().any(|n| n.name == market.node) {
         errors.push(ValidationError::new("node", "no such node"));
     }
-    if groups
-        .iter()
-        .find(|g| g.name == market.process_group)
-        .is_none()
-    {
+    if !groups.iter().any(|g| g.name == market.process_group) {
         errors.push(ValidationError::new("processgroup", "no such group"));
     }
     if let Some(ref reserve_type) = market.reserve_type {

--- a/src/graphql/node_delay_input.rs
+++ b/src/graphql/node_delay_input.rs
@@ -1,0 +1,76 @@
+use super::{ValidationError, ValidationErrors};
+use crate::input_data_base::{BaseNode, Delay};
+use juniper::GraphQLInputObject;
+
+#[derive(GraphQLInputObject)]
+pub struct NewNodeDelay {
+    from_node: String,
+    to_node: String,
+    delay: f64,
+    min_delay_flow: f64,
+    max_delay_flow: f64,
+}
+
+impl NewNodeDelay {
+    fn to_delay(self) -> Delay {
+        Delay {
+            from_node: self.from_node,
+            to_node: self.to_node,
+            delay: self.delay,
+            min_delay_flow: self.min_delay_flow,
+            max_delay_flow: self.max_delay_flow,
+        }
+    }
+}
+
+pub fn create_node_delay(
+    delay: NewNodeDelay,
+    delays: &mut Vec<Delay>,
+    nodes: &Vec<BaseNode>,
+) -> ValidationErrors {
+    let errors = validate_node_creation(&delay, delays, nodes);
+    if !errors.is_empty() {
+        return ValidationErrors::from(errors);
+    }
+    delays.push(delay.to_delay());
+    ValidationErrors::default()
+}
+
+fn validate_node_creation(
+    delay: &NewNodeDelay,
+    delays: &Vec<Delay>,
+    nodes: &Vec<BaseNode>,
+) -> Vec<ValidationError> {
+    let mut errors = Vec::new();
+    if delay.from_node.is_empty() {
+        errors.push(ValidationError::new("from_node", "node name is empty"));
+    }
+    if delay.to_node.is_empty() {
+        errors.push(ValidationError::new("to_node", "node name is empty"));
+    }
+    if delay.from_node == delay.to_node {
+        errors.push(ValidationError::new("from_node", "same as to_node"));
+    }
+    if !nodes.iter().any(|n| n.name == delay.from_node) {
+        errors.push(ValidationError::new("from_node", "no such node"));
+    }
+    if !nodes.iter().any(|n| n.name == delay.to_node) {
+        errors.push(ValidationError::new("to_node", "no such node"));
+    }
+    if delays
+        .iter()
+        .any(|d| d.from_node == delay.from_node && d.to_node == delay.to_node)
+    {
+        errors.push(ValidationError::new(
+            "from_node",
+            "a delay with same from_node and to_node exists",
+        ));
+    }
+    if delay.min_delay_flow > delay.max_delay_flow {
+        errors.push(ValidationError::new(
+            "min_delay_flow",
+            "greater than max_delay_flow",
+        ))
+    }
+    errors
+}

--- a/src/graphql/node_diffusion_input.rs
+++ b/src/graphql/node_diffusion_input.rs
@@ -37,16 +37,15 @@ fn validate_node_diffusion_creation(
             "to node and from node are the same",
         ));
     }
-    if nodes.iter().find(|n| n.name == *from_node).is_none() {
+    if !nodes.iter().any(|n| n.name == *from_node) {
         errors.push(ValidationError::new("from_node", "no such node"));
     }
-    if nodes.iter().find(|n| n.name == *to_node).is_none() {
+    if !nodes.iter().any(|n| n.name == *to_node) {
         errors.push(ValidationError::new("to_node", "no such node"));
     }
     if diffusions
         .iter()
-        .find(|d| d.from_node == *from_node && d.to_node == *to_node)
-        .is_some()
+        .any(|d| d.from_node == *from_node && d.to_node == *to_node)
     {
         errors.push(ValidationError::new(
             "from_node",

--- a/src/graphql/node_history_input.rs
+++ b/src/graphql/node_history_input.rs
@@ -1,0 +1,84 @@
+use super::time_line_input::DurationInput;
+use super::{MaybeError, ValidationError, ValidationErrors};
+use crate::input_data_base::{BaseNode, BaseNodeHistory, Series};
+use crate::scenarios::Scenario;
+use juniper::GraphQLInputObject;
+
+pub fn create_node_history(
+    node_name: String,
+    histories: &mut Vec<BaseNodeHistory>,
+    nodes: &Vec<BaseNode>,
+) -> MaybeError {
+    if !nodes.iter().any(|n| n.name == node_name) {
+        return "no such node".into();
+    }
+    histories.push(BaseNodeHistory::new(node_name));
+    MaybeError::new_ok()
+}
+
+#[derive(GraphQLInputObject)]
+pub struct NewSeries {
+    scenario: String,
+    durations: Vec<DurationInput>,
+    values: Vec<f64>,
+}
+
+impl NewSeries {
+    fn to_series(self) -> Result<Series, String> {
+        let mut durations = Vec::with_capacity(self.durations.len());
+        for duration in self.durations {
+            durations.push(duration.to_duration()?);
+        }
+        Ok(Series {
+            scenario: self.scenario,
+            durations,
+            values: self.values,
+        })
+    }
+}
+
+pub fn add_step_to_node_history(
+    node_name: String,
+    step: NewSeries,
+    histories: &mut Vec<BaseNodeHistory>,
+    scenarios: &Vec<Scenario>,
+) -> ValidationErrors {
+    let history = match histories.iter_mut().find(|h| h.node == node_name) {
+        Some(history) => history,
+        None => return ValidationError::new("node_name", "no history for node").into(),
+    };
+    let errors = validate_step_addition(&step, history, scenarios);
+    if !errors.is_empty() {
+        return errors.into();
+    }
+    let history_step = match step.to_series() {
+        Ok(series) => series,
+        Err(error) => return ValidationError::new("durations", &error).into(),
+    };
+    history.steps.push(history_step);
+    ValidationErrors::default()
+}
+
+fn validate_step_addition(
+    step: &NewSeries,
+    history: &BaseNodeHistory,
+    scenarios: &Vec<Scenario>,
+) -> Vec<ValidationError> {
+    let mut errors = Vec::new();
+    if !scenarios.iter().any(|s| *s.name() == step.scenario) {
+        errors.push(ValidationError::new("scenario", "no such scenario"));
+    }
+    if history.steps.iter().any(|s| s.scenario == step.scenario) {
+        errors.push(ValidationError::new(
+            "scenario",
+            "a step with same scenario exists",
+        ));
+    }
+    if step.durations.len() != step.values.len() {
+        errors.push(ValidationError::new(
+            "durations",
+            "length does not match values",
+        ));
+    }
+    errors
+}

--- a/src/graphql/node_input.rs
+++ b/src/graphql/node_input.rs
@@ -65,13 +65,13 @@ fn validate_node_creation(
     if node.name.is_empty() {
         errors.push(ValidationError::new("name", "name is empty"));
     }
-    if nodes.iter().find(|n| n.name == node.name).is_some() {
+    if nodes.iter().any(|n| n.name == node.name) {
         errors.push(ValidationError::new(
             "name",
             "a node with the same name exists",
         ));
     }
-    if processes.iter().find(|p| p.name == node.name).is_some() {
+    if processes.iter().any(|p| p.name == node.name) {
         errors.push(ValidationError::new(
             "name",
             "a process with the same name exists",

--- a/src/graphql/process_input.rs
+++ b/src/graphql/process_input.rs
@@ -78,13 +78,13 @@ fn validate_process_creation(
     if process.name.is_empty() {
         errors.push(ValidationError::new("name", "name is empty"));
     }
-    if processes.iter().find(|p| p.name == process.name).is_some() {
+    if processes.iter().any(|p| p.name == process.name) {
         errors.push(ValidationError::new(
             "name",
             "a process with the same name exists",
         ));
     }
-    if nodes.iter().find(|n| n.name == process.name).is_some() {
+    if nodes.iter().any(|n| n.name == process.name) {
         errors.push(ValidationError::new(
             "name",
             "a node with the same name exists",

--- a/src/graphql/scenario_input.rs
+++ b/src/graphql/scenario_input.rs
@@ -6,7 +6,7 @@ pub fn create_scenario(name: String, weight: f64, scenarios: &mut Vec<Scenario>)
     if name.is_empty() {
         return "name is empty".into();
     }
-    if scenarios.iter().find(|s| *s.name() == name).is_some() {
+    if scenarios.iter().any(|s| *s.name() == name) {
         return "a scenario with the same name exists".into();
     }
     let scenario = match Scenario::new(&name, weight) {

--- a/src/graphql/scenario_input.rs
+++ b/src/graphql/scenario_input.rs
@@ -1,5 +1,6 @@
 use super::delete;
 use super::MaybeError;
+use crate::input_data_base::BaseNodeHistory;
 use crate::scenarios::Scenario;
 
 pub fn create_scenario(name: String, weight: f64, scenarios: &mut Vec<Scenario>) -> MaybeError {
@@ -17,6 +18,17 @@ pub fn create_scenario(name: String, weight: f64, scenarios: &mut Vec<Scenario>)
     MaybeError::new_ok()
 }
 
-pub fn delete_scenario(name: &str, scenarios: &mut Vec<Scenario>) -> MaybeError {
-    delete::delete_named(name, scenarios)
+pub fn delete_scenario(
+    name: &str,
+    scenarios: &mut Vec<Scenario>,
+    node_histories: &mut Vec<BaseNodeHistory>,
+) -> MaybeError {
+    let maybe_error = delete::delete_named(name, scenarios);
+    if maybe_error.is_error() {
+        return maybe_error;
+    }
+    for history in node_histories {
+        history.steps.retain(|s| s.scenario != name);
+    }
+    MaybeError::new_ok()
 }

--- a/src/graphql/topology_input.rs
+++ b/src/graphql/topology_input.rs
@@ -77,12 +77,12 @@ fn validate_topology_creation(
         ));
     }
     if let Some(ref sink) = sink_node {
-        if nodes.iter().find(|n| n.name == *sink).is_none() {
+        if !nodes.iter().any(|n| n.name == *sink) {
             errors.push(ValidationError::new("sink_node", "no such node"));
         }
     }
     if let Some(ref source) = source_node {
-        if nodes.iter().find(|n| n.name == *source).is_none() {
+        if !nodes.iter().any(|n| n.name == *source) {
             errors.push(ValidationError::new("source_node", "no such node"));
         }
     }
@@ -97,8 +97,7 @@ fn validate_topology_creation(
     if process
         .topos
         .iter()
-        .find(|t| t.source == *source && t.sink == *sink)
-        .is_some()
+        .any(|t| t.source == *source && t.sink == *sink)
     {
         errors.push(ValidationError::new(
             "process_name",

--- a/src/input_data_base.rs
+++ b/src/input_data_base.rs
@@ -435,12 +435,7 @@ impl BaseProcess {
             .input_data
             .process_groups
             .iter()
-            .filter(|&g| {
-                self.groups
-                    .iter()
-                    .find(|&g_name| *g_name == g.name)
-                    .is_some()
-            })
+            .filter(|&g| self.groups.iter().any(|g_name| *g_name == g.name))
             .cloned()
             .collect()
     }
@@ -593,12 +588,7 @@ impl BaseNode {
             .input_data
             .node_groups
             .iter()
-            .filter(|&g| {
-                self.groups
-                    .iter()
-                    .find(|&g_name| *g_name == g.name)
-                    .is_some()
-            })
+            .filter(|&g| self.groups.iter().any(|g_name| *g_name == g.name))
             .cloned()
             .collect()
     }
@@ -953,7 +943,7 @@ impl NodeGroup {
             .input_data
             .nodes
             .iter()
-            .filter(|&n| self.members.iter().find(|&m| *m == n.name).is_some())
+            .filter(|&n| self.members.iter().any(|m| *m == n.name))
             .cloned()
             .collect()
     }
@@ -1002,7 +992,7 @@ impl ProcessGroup {
             .input_data
             .processes
             .iter()
-            .filter(|&n| self.members.iter().find(|&m| *m == n.name).is_some())
+            .filter(|&n| self.members.iter().any(|m| *m == n.name))
             .cloned()
             .collect()
     }


### PR DESCRIPTION
This PR adds GraphQL mutations to create node delays and histories.

**Breaking**: node history steps are scalars no more. Instead, the steps are defined by durations from the start of the current time line and a corresponding inflow value.