### PR TITLE
Add GraphQL mutations that delete node delays, histories and clear history steps

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -724,7 +724,16 @@ impl Mutation {
         )
     }
 
-    async fn create_node_history(node_name: String, context: &HerttaContext) -> MaybeError {
+    async fn delete_node_delay(
+        from_node: String,
+        to_node: String,
+        context: &HerttaContext,
+    ) -> MaybeError {
+        let mut model = context.model.lock().await;
+        node_delay_input::delete_node_delay(&from_node, &to_node, &mut model.input_data.node_delay)
+    }
+
+    async fn create_node_history(node_name: String, context: &HerttaContext) -> ValidationErrors {
         let mut model_ref = context.model.lock().await;
         let model = model_ref.deref_mut();
         node_history_input::create_node_history(
@@ -732,6 +741,11 @@ impl Mutation {
             &mut model.input_data.node_histories,
             &model.input_data.nodes,
         )
+    }
+
+    async fn delete_node_history(node_name: String, context: &HerttaContext) -> MaybeError {
+        let mut model = context.model.lock().await;
+        node_history_input::delete_node_history(&node_name, &mut model.input_data.node_histories)
     }
 
     async fn add_step_to_node_history(
@@ -746,6 +760,14 @@ impl Mutation {
             step,
             &mut model.input_data.node_histories,
             &model.input_data.scenarios,
+        )
+    }
+
+    async fn clear_node_history_steps(node_name: String, context: &HerttaContext) -> MaybeError {
+        let mut model = context.model.lock().await;
+        node_history_input::clear_node_history_steps(
+            &node_name,
+            &mut model.input_data.node_histories,
         )
     }
 

--- a/src/graphql/node_delay_input.rs
+++ b/src/graphql/node_delay_input.rs
@@ -1,4 +1,4 @@
-use super::{ValidationError, ValidationErrors};
+use super::{MaybeError, ValidationError, ValidationErrors};
 use crate::input_data_base::{BaseNode, Delay};
 use juniper::GraphQLInputObject;
 
@@ -73,4 +73,16 @@ fn validate_node_creation(
         ))
     }
     errors
+}
+
+pub fn delete_node_delay(from_node: &str, to_node: &str, delays: &mut Vec<Delay>) -> MaybeError {
+    let position = match delays
+        .iter()
+        .position(|d| d.from_node == from_node && d.to_node == to_node)
+    {
+        Some(position) => position,
+        None => return "no such node delay".into(),
+    };
+    delays.swap_remove(position);
+    MaybeError::new_ok()
 }

--- a/src/graphql/node_history_input.rs
+++ b/src/graphql/node_history_input.rs
@@ -8,11 +8,23 @@ pub fn create_node_history(
     node_name: String,
     histories: &mut Vec<BaseNodeHistory>,
     nodes: &Vec<BaseNode>,
-) -> MaybeError {
+) -> ValidationErrors {
     if !nodes.iter().any(|n| n.name == node_name) {
-        return "no such node".into();
+        return ValidationError::new("node_name", "no such node").into();
+    }
+    if histories.iter().any(|h| h.node == node_name) {
+        return ValidationError::new("node_name", "a history for the node exists").into();
     }
     histories.push(BaseNodeHistory::new(node_name));
+    ValidationErrors::default()
+}
+
+pub fn delete_node_history(node_name: &str, histories: &mut Vec<BaseNodeHistory>) -> MaybeError {
+    let position = match histories.iter().position(|h| h.node == node_name) {
+        Some(position) => position,
+        None => return "no such node history".into(),
+    };
+    histories.swap_remove(position);
     MaybeError::new_ok()
 }
 
@@ -81,4 +93,16 @@ fn validate_step_addition(
         ));
     }
     errors
+}
+
+pub fn clear_node_history_steps(
+    node_name: &str,
+    histories: &mut Vec<BaseNodeHistory>,
+) -> MaybeError {
+    let history = match histories.iter_mut().find(|h| h.node == node_name) {
+        Some(history) => history,
+        None => return "no such node history".into(),
+    };
+    history.steps.clear();
+    MaybeError::new_ok()
 }


### PR DESCRIPTION
Added more deletions.

**Breaking**: `createNodeHistory` now returns `ValidationErrors` instead of `MaybeError` to be consistent with the other create mutations.