### PR TITLE
Fix outside temperature inflow and use a special enum to mark inflows that need to be replaced by forecast

### DIFF
--- a/src/event_loop/optimization_job.rs
+++ b/src/event_loop/optimization_job.rs
@@ -6,7 +6,7 @@ use super::time_series;
 use super::utilities;
 use super::weather_forecast_job;
 use super::{ElectricityPriceData, OptimizationData, WeatherData};
-use crate::input_data::{InputData, Market, TimeSeries, TimeSeriesData};
+use crate::input_data::{Inflow, InputData, Market, TimeSeries, TimeSeriesData};
 use crate::input_data_base::{self, BaseInputData, BaseProcess};
 use crate::model::Model;
 use crate::scenarios::Scenario;
@@ -675,40 +675,72 @@ fn update_outside_node(
     input_data: &mut InputData,
     weather_data: WeatherData,
 ) -> Result<(), String> {
-    let outside_node_name = "outside";
     let nodes = &mut input_data.nodes;
-    let outside_node = nodes
-        .get_mut(outside_node_name)
-        .ok_or("outside node not found in nodes".to_string())?;
-    if !outside_node.is_inflow {
-        return Err("outside node is not marked for inflow".to_string());
+    for (node_name, node) in nodes {
+        if let Inflow::TemperatureForecast(_) = node.inflow {
+            if !node.is_inflow {
+                return Err(format!("{} node is not marked for inflow", node_name));
+            }
+            let state = match &mut node.state {
+                Some(state) => state,
+                None => return Err(format!("{} node has no state", node_name)),
+            };
+            if !state.is_temp {
+                return Err(format!(
+                    "{} node state is not marked as temperature",
+                    node_name
+                ));
+            }
+            if state.state_min > state.state_max {
+                return Err(format!(
+                    "{} node state has state_min greater than state_max",
+                    node_name
+                ));
+            }
+            let initial_temperature = weather_data
+                .first()
+                .expect("weather data should have at least one time series")
+                .series
+                .values()
+                .next()
+                .expect("weather data should have at least one data point");
+            if state.state_min > *initial_temperature {
+                return Err("forecast temperature is below outside node state_min".to_string());
+            }
+            if state.state_max < *initial_temperature {
+                return Err("forecast temperature is above outside node state_max".to_string());
+            }
+            state.initial_state = *initial_temperature;
+            node.inflow = Inflow::TimeSeriesData(
+                weather_data
+                    .iter()
+                    .map(|d| time_series_diffs(*initial_temperature, d))
+                    .collect::<Vec<TimeSeries>>()
+                    .into(),
+            );
+        }
     }
-    let state = match &mut outside_node.state {
-        Some(state) => state,
-        None => return Err("outside node has no state".to_string()),
-    };
-    if !state.is_temp {
-        return Err("outside node state is not marked as temperature".to_string());
-    }
-    if state.state_min > state.state_max {
-        return Err("outside node state has state_min greater than state_max".to_string());
-    }
-    let initial_temperature = weather_data
-        .first()
-        .expect("weather data should have at least one time series")
-        .series
-        .values()
-        .next()
-        .expect("weather data should have at least one data point");
-    if state.state_min > *initial_temperature {
-        return Err("forecast temperature is below outside node state_min".to_string());
-    }
-    if state.state_max < *initial_temperature {
-        return Err("forecast temperature is above outside node state_max".to_string());
-    }
-    state.initial_state = *initial_temperature;
-    outside_node.inflow.ts_data = weather_data;
     Ok(())
+}
+
+fn time_series_diffs(initial_value: f64, time_series: &TimeSeries) -> TimeSeries {
+    let diff_values = diffs(initial_value, &time_series.series);
+    TimeSeries {
+        scenario: time_series.scenario.clone(),
+        series: diff_values,
+    }
+}
+
+fn diffs(
+    mut initial_value: f64,
+    time_series: &BTreeMap<TimeStamp, f64>,
+) -> BTreeMap<TimeStamp, f64> {
+    let mut diff_values = BTreeMap::new();
+    for (time_stamp, value) in time_series {
+        diff_values.insert(time_stamp.clone(), value - initial_value);
+        initial_value = *value;
+    }
+    diff_values
 }
 
 // Function to create TimeSeriesData from weather values and update the weather_data field in optimization_data

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -665,6 +665,19 @@ impl Mutation {
         state_input::update_state_in_node(state, node_name, &mut model.input_data.nodes)
     }
 
+    async fn connect_node_inflow_to_temperature_forecast(
+        node_name: String,
+        forecast_name: String,
+        context: &HerttaContext,
+    ) -> MaybeError {
+        let mut model = context.model.lock().await;
+        node_input::connect_node_inflow_to_temperature_forecast(
+            &node_name,
+            forecast_name,
+            &mut model.input_data.nodes,
+        )
+    }
+
     #[graphql(description = "Delete a node and all items that depend on that node.")]
     async fn delete_node(name: String, context: &HerttaContext) -> MaybeError {
         let mut model_ref = context.model.lock().await;

--- a/tests/predicer/predicer_all.json
+++ b/tests/predicer/predicer_all.json
@@ -1,1888 +1,1662 @@
 {
-    "temporals":{
-       "t":[
-          "2022-04-20T00:00:00+00:00",
-          "2022-04-20T01:00:00+00:00",
-          "2022-04-20T02:00:00+00:00"
-       ],
-       "dtf":1.0,
-       "is_variable_dt":false,
-       "variable_dt":[
-
-       ],
-       "ts_format":"yyyy-mm-ddTHH:MM:SSzzzz"
-    },
-    "setup":{
-       "contains_reserves":true,
-       "contains_online":true,
-       "contains_states":true,
-       "contains_piecewise_eff":true,
-       "contains_risk":true,
-       "contains_diffusion":true,
-       "contains_delay":false,
-       "contains_markets":true,
-       "reserve_realisation":true,
-       "use_market_bids":true,
-       "common_timesteps":2,
-       "common_scenario_name":"s_all",
-       "use_node_dummy_variables":true,
-       "use_ramp_dummy_variables":true,
-       "node_dummy_variable_cost":10000.0,
-       "ramp_dummy_variable_cost":10000.0
-    },
-    "processes":{
-       "ngchp":{
-          "name":"ngchp",
-          "groups":[
-             "p1"
-          ],
-          "conversion":1,
-          "is_cf":false,
-          "is_cf_fix":false,
-          "is_online":true,
-          "is_res":true,
-          "eff":0.9,
-          "load_min":0.3,
-          "load_max":1.0,
-          "start_cost":0.0,
-          "min_online":4,
-          "min_offline":3,
-          "max_online":0,
-          "max_offline":0,
-          "initial_state":true,
-          "is_scenario_independent":true,
-          "topos":[
-             {
-                "source":"ng",
-                "sink":"ngchp",
-                "capacity":20.0,
-                "vom_cost":3.0,
-                "ramp_up":0.5,
-                "ramp_down":0.5,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-
-                   ],
-                   "index":{
-
-                   }
-                }
-             },
-             {
-                "source":"ngchp",
-                "sink":"dh",
-                "capacity":10.0,
-                "vom_cost":0.0,
-                "ramp_up":0.5,
-                "ramp_down":0.5,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-
-                   ],
-                   "index":{
-
-                   }
-                }
-             },
-             {
-                "source":"ngchp",
-                "sink":"elc",
-                "capacity":8.0,
-                "vom_cost":0.0,
-                "ramp_up":0.5,
-                "ramp_down":0.5,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-
-                   ],
-                   "index":{
-
-                   }
-                }
-             }
-          ],
-          "cf":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ts":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ops":[
-             "op1",
-             "op2",
-             "op3",
-             "op4",
-             "op5"
-          ],
-          "eff_fun":[
-             [
-                0.4,
-                0.8
-             ],
-             [
-                0.6,
-                0.78
-             ],
-             [
-                0.8,
-                0.75
-             ],
-             [
-                0.9,
-                0.7
-             ],
-             [
-                1,
-                0.65
-             ]
-          ]
-       },
-       "hp1":{
-          "name":"hp1",
-          "groups":[
-             "p1"
-          ],
-          "conversion":1,
-          "is_cf":false,
-          "is_cf_fix":false,
-          "is_online":false,
-          "is_res":true,
-          "eff":3.0,
-          "load_min":0.0,
-          "load_max":1.0,
-          "start_cost":0.0,
-          "min_online":0,
-          "min_offline":0,
-          "max_online":0,
-          "max_offline":0,
-          "initial_state":false,
-          "is_scenario_independent":false,
-          "topos":[
-             {
-                "source":"elc",
-                "sink":"hp1",
-                "capacity":5.0,
-                "vom_cost":15.0,
-                "ramp_up":0.5,
-                "ramp_down":0.5,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-                      {
-                         "scenario":"s1",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":5,
-                            "2022-04-20T01:00:00+00:00":4.285714285714286,
-                            "2022-04-20T02:00:00+00:00":4.285714285714286
-                         }
-                      },
-                      {
-                         "scenario":"s2",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":5,
-                            "2022-04-20T01:00:00+00:00":4.285714285714286,
-                            "2022-04-20T02:00:00+00:00":4.285714285714286
-                         }
-                      },
-                      {
-                         "scenario":"s3",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":5,
-                            "2022-04-20T01:00:00+00:00":4.28571428571429,
-                            "2022-04-20T02:00:00+00:00":4.28571428571429
-                         }
-                      }
-                   ],
-                   "index":{
-                      "s1":1,
-                      "s2":2,
-                      "s3":3
-                   }
-                }
-             },
-             {
-                "source":"hp1",
-                "sink":"dh",
-                "capacity":15.0,
-                "vom_cost":0.5,
-                "ramp_up":0.5,
-                "ramp_down":0.5,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-
-                   ],
-                   "index":{
-
-                   }
-                }
-             }
-          ],
-          "cf":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ts":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":3,
-                      "2022-04-20T01:00:00+00:00":3.5,
-                      "2022-04-20T02:00:00+00:00":3.5
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":3,
-                      "2022-04-20T01:00:00+00:00":3.5,
-                      "2022-04-20T02:00:00+00:00":3.5
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":3,
-                      "2022-04-20T01:00:00+00:00":3.5,
-                      "2022-04-20T02:00:00+00:00":3.5
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          },
-          "eff_ops":[
-
-          ],
-          "eff_fun":[
-
-          ]
-       },
-       "p2x1":{
-          "name":"p2x1",
-          "groups":[
-             "p1"
-          ],
-          "conversion":1,
-          "is_cf":false,
-          "is_cf_fix":false,
-          "is_online":false,
-          "is_res":true,
-          "eff":0.7,
-          "load_min":0.0,
-          "load_max":1.0,
-          "start_cost":0.0,
-          "min_online":0,
-          "min_offline":0,
-          "max_online":0,
-          "max_offline":0,
-          "initial_state":false,
-          "is_scenario_independent":false,
-          "topos":[
-             {
-                "source":"elc",
-                "sink":"p2x1",
-                "capacity":10.0,
-                "vom_cost":15.0,
-                "ramp_up":1.0,
-                "ramp_down":1.0,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-
-                   ],
-                   "index":{
-
-                   }
-                }
-             },
-             {
-                "source":"p2x1",
-                "sink":"h2",
-                "capacity":7.0,
-                "vom_cost":1.0,
-                "ramp_up":1.0,
-                "ramp_down":1.0,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-
-                   ],
-                   "index":{
-
-                   }
-                }
-             }
-          ],
-          "cf":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ts":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ops":[
-
-          ],
-          "eff_fun":[
-
-          ]
-       },
-       "pv1":{
-          "name":"pv1",
-          "groups":[
-
-          ],
-          "conversion":1,
-          "is_cf":true,
-          "is_cf_fix":true,
-          "is_online":false,
-          "is_res":false,
-          "eff":1.0,
-          "load_min":0.0,
-          "load_max":1.0,
-          "start_cost":0.0,
-          "min_online":0,
-          "min_offline":0,
-          "max_online":0,
-          "max_offline":0,
-          "initial_state":false,
-          "is_scenario_independent":false,
-          "topos":[
-             {
-                "source":"pv1",
-                "sink":"elc",
-                "capacity":5.0,
-                "vom_cost":0.5,
-                "ramp_up":1.0,
-                "ramp_down":1.0,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-
-                   ],
-                   "index":{
-
-                   }
-                }
-             }
-          ],
-          "cf":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":0,
-                      "2022-04-20T01:00:00+00:00":0.4,
-                      "2022-04-20T02:00:00+00:00":0.5
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":0,
-                      "2022-04-20T01:00:00+00:00":0.4,
-                      "2022-04-20T02:00:00+00:00":0.5
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":0,
-                      "2022-04-20T01:00:00+00:00":0.4,
-                      "2022-04-20T02:00:00+00:00":0.5
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          },
-          "eff_ts":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ops":[
-
-          ],
-          "eff_fun":[
-
-          ]
-       },
-       "dh_tra":{
-          "name":"dh_tra",
-          "groups":[
-
-          ],
-          "conversion":2,
-          "is_cf":false,
-          "is_cf_fix":false,
-          "is_online":false,
-          "is_res":false,
-          "eff":0.99,
-          "load_min":0.0,
-          "load_max":1.0,
-          "start_cost":0.0,
-          "min_online":0,
-          "min_offline":0,
-          "max_online":0,
-          "max_offline":0,
-          "initial_state":false,
-          "is_scenario_independent":false,
-          "topos":[
-             {
-                "source":"dh",
-                "sink":"dh2",
-                "capacity":20.0,
-                "vom_cost":0.0,
-                "ramp_up":1.0,
-                "ramp_down":1.0,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-
-                   ],
-                   "index":{
-
-                   }
-                }
-             }
-          ],
-          "cf":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ts":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ops":[
-
-          ],
-          "eff_fun":[
-
-          ]
-       },
-       "dh_sto_charge":{
-          "name":"dh_sto_charge",
-          "groups":[
-
-          ],
-          "conversion":1,
-          "is_cf":false,
-          "is_cf_fix":false,
-          "is_online":false,
-          "is_res":false,
-          "eff":0.99,
-          "load_min":0.0,
-          "load_max":1.0,
-          "start_cost":0.0,
-          "min_online":0,
-          "min_offline":0,
-          "max_online":0,
-          "max_offline":0,
-          "initial_state":false,
-          "is_scenario_independent":false,
-          "topos":[
-             {
-                "source":"dh",
-                "sink":"dh_sto_charge",
-                "capacity":20.0,
-                "vom_cost":0.0,
-                "ramp_up":1.0,
-                "ramp_down":1.0,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-
-                   ],
-                   "index":{
-
-                   }
-                }
-             },
-             {
-                "source":"dh_sto_charge",
-                "sink":"dh_sto",
-                "capacity":20.0,
-                "vom_cost":0.0,
-                "ramp_up":1.0,
-                "ramp_down":1.0,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-
-                   ],
-                   "index":{
-
-                   }
-                }
-             }
-          ],
-          "cf":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ts":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ops":[
-
-          ],
-          "eff_fun":[
-
-          ]
-       },
-       "dh_sto_discharge":{
-          "name":"dh_sto_discharge",
-          "groups":[
-
-          ],
-          "conversion":1,
-          "is_cf":false,
-          "is_cf_fix":false,
-          "is_online":false,
-          "is_res":false,
-          "eff":0.99,
-          "load_min":0.0,
-          "load_max":1.0,
-          "start_cost":0.0,
-          "min_online":0,
-          "min_offline":0,
-          "max_online":0,
-          "max_offline":0,
-          "initial_state":false,
-          "is_scenario_independent":false,
-          "topos":[
-             {
-                "source":"dh_sto",
-                "sink":"dh_sto_discharge",
-                "capacity":20.0,
-                "vom_cost":0.0,
-                "ramp_up":1.0,
-                "ramp_down":1.0,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-
-                   ],
-                   "index":{
-
-                   }
-                }
-             },
-             {
-                "source":"dh_sto_discharge",
-                "sink":"dh",
-                "capacity":20.0,
-                "vom_cost":0.0,
-                "ramp_up":1.0,
-                "ramp_down":1.0,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-
-                   ],
-                   "index":{
-
-                   }
-                }
-             }
-          ],
-          "cf":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ts":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ops":[
-
-          ],
-          "eff_fun":[
-
-          ]
-       },
-       "dh_source_out":{
-          "name":"dh_source_out",
-          "groups":[
-
-          ],
-          "conversion":2,
-          "is_cf":false,
-          "is_cf_fix":false,
-          "is_online":false,
-          "is_res":false,
-          "eff":1.0,
-          "load_min":0.0,
-          "load_max":1.0,
-          "start_cost":0.0,
-          "min_online":0,
-          "min_offline":0,
-          "max_online":0,
-          "max_offline":0,
-          "initial_state":false,
-          "is_scenario_independent":false,
-          "topos":[
-             {
-                "source":"dh_source_out",
-                "sink":"dh",
-                "capacity":1000.0,
-                "vom_cost":0.0,
-                "ramp_up":1.0,
-                "ramp_down":1.0,
-                "initial_load":0.6,
-                "initial_flow":0.6,
-                "cap_ts":{
-                   "ts_data":[
-
-                   ],
-                   "index":{
-
-                   }
-                }
-             }
-          ],
-          "cf":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ts":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "eff_ops":[
-
-          ],
-          "eff_fun":[
-
-          ]
-       }
-    },
-    "nodes":{
-       "ng":{
-          "name":"ng",
-          "groups":[
-
-          ],
-          "is_commodity":true,
-          "is_market":false,
-          "is_state":false,
-          "is_res":false,
-          "is_inflow":false,
-          "state":null,
-          "cost":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":12,
-                      "2022-04-20T01:00:00+00:00":12,
-                      "2022-04-20T02:00:00+00:00":12
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":12,
-                      "2022-04-20T01:00:00+00:00":12,
-                      "2022-04-20T02:00:00+00:00":12
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":12,
-                      "2022-04-20T01:00:00+00:00":12,
-                      "2022-04-20T02:00:00+00:00":12
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          },
-          "inflow":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          }
-       },
-       "elc":{
-          "name":"elc",
-          "groups":[
-             "elc_res"
-          ],
-          "is_commodity":false,
-          "is_market":false,
-          "is_state":false,
-          "is_res":true,
-          "is_inflow":false,
-          "state":null,
-          "cost":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "inflow":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          }
-       },
-       "dh":{
-          "name":"dh",
-          "groups":[
-
-          ],
-          "is_commodity":false,
-          "is_market":false,
-          "is_state":false,
-          "is_res":false,
-          "is_inflow":false,
-          "state":null,
-          "cost":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "inflow":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          }
-       },
-       "h2":{
-          "name":"h2",
-          "groups":[
-
-          ],
-          "is_commodity":false,
-          "is_market":false,
-          "is_state":true,
-          "is_res":false,
-          "is_inflow":true,
-          "state":{
-             "in_max":1.0,
-             "out_max":1.0,
-             "state_loss_proportional":0.0,
-             "state_max":4.0,
-             "state_min":0.0,
-             "initial_state":0.0,
-             "is_scenario_independent":false,
-             "is_temp":false,
-             "t_e_conversion":1.0,
-             "residual_value":0.0
-          },
-          "cost":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "inflow":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":-5,
-                      "2022-04-20T01:00:00+00:00":-5,
-                      "2022-04-20T02:00:00+00:00":-6
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":-5,
-                      "2022-04-20T01:00:00+00:00":-5,
-                      "2022-04-20T02:00:00+00:00":-6
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":-5,
-                      "2022-04-20T01:00:00+00:00":-5,
-                      "2022-04-20T02:00:00+00:00":-6
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          }
-       },
-       "dh2":{
-          "name":"dh2",
-          "groups":[
-
-          ],
-          "is_commodity":false,
-          "is_market":false,
-          "is_state":false,
-          "is_res":false,
-          "is_inflow":true,
-          "state":null,
-          "cost":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "inflow":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":-5,
-                      "2022-04-20T01:00:00+00:00":-5,
-                      "2022-04-20T02:00:00+00:00":-4
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":-5,
-                      "2022-04-20T01:00:00+00:00":-5,
-                      "2022-04-20T02:00:00+00:00":-4
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":-5,
-                      "2022-04-20T01:00:00+00:00":-5,
-                      "2022-04-20T02:00:00+00:00":-4
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          }
-       },
-       "dh_sto":{
-          "name":"dh_sto",
-          "groups":[
-
-          ],
-          "is_commodity":false,
-          "is_market":false,
-          "is_state":true,
-          "is_res":false,
-          "is_inflow":false,
-          "state":{
-             "in_max":20.0,
-             "out_max":20.0,
-             "state_loss_proportional":0.0,
-             "state_max":393.15,
-             "state_min":330.15,
-             "initial_state":373.15,
-             "is_scenario_independent":false,
-             "is_temp":true,
-             "t_e_conversion":0.23277777777777803,
-             "residual_value":20.0
-          },
-          "cost":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "inflow":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          }
-       },
-       "ambience":{
-          "name":"ambience",
-          "groups":[
-
-          ],
-          "is_commodity":false,
-          "is_market":false,
-          "is_state":true,
-          "is_res":false,
-          "is_inflow":true,
-          "state":{
-             "in_max":1.0e8,
-             "out_max":1.0e8,
-             "state_loss_proportional":0.0,
-             "state_max":300.15,
-             "state_min":253.15,
-             "initial_state":273.15,
-             "is_scenario_independent":false,
-             "is_temp":true,
-             "t_e_conversion":1.0e7,
-             "residual_value":0.0
-          },
-          "cost":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "inflow":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":-1,
-                      "2022-04-20T01:00:00+00:00":0,
-                      "2022-04-20T02:00:00+00:00":-2
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":-1,
-                      "2022-04-20T01:00:00+00:00":0,
-                      "2022-04-20T02:00:00+00:00":0
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":-1,
-                      "2022-04-20T01:00:00+00:00":0,
-                      "2022-04-20T02:00:00+00:00":0
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          }
-       },
-       "delay_source":{
-          "name":"delay_source",
-          "groups":[
-
-          ],
-          "is_commodity":false,
-          "is_market":false,
-          "is_state":false,
-          "is_res":false,
-          "is_inflow":true,
-          "state":null,
-          "cost":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "inflow":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":1,
-                      "2022-04-20T01:00:00+00:00":1,
-                      "2022-04-20T02:00:00+00:00":2
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":1,
-                      "2022-04-20T01:00:00+00:00":1,
-                      "2022-04-20T02:00:00+00:00":2
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":1,
-                      "2022-04-20T01:00:00+00:00":1,
-                      "2022-04-20T02:00:00+00:00":2
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          }
-       },
-       "dh_source":{
-          "name":"dh_source",
-          "groups":[
-
-          ],
-          "is_commodity":false,
-          "is_market":false,
-          "is_state":true,
-          "is_res":false,
-          "is_inflow":false,
-          "state":{
-             "in_max":1000.0,
-             "out_max":1000.0,
-             "state_loss_proportional":0.9,
-             "state_max":1000.0,
-             "state_min":0.0,
-             "initial_state":0.0,
-             "is_scenario_independent":false,
-             "is_temp":false,
-             "t_e_conversion":1.0,
-             "residual_value":0.0
-          },
-          "cost":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "inflow":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          }
-       }
-    },
-    "node_diffusion":[
-       {
-          "node1":"dh_sto",
-          "node2":"ambience",
-          "coefficient":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":0.02,
-                      "2022-04-20T01:00:00+00:00":0.02,
-                      "2022-04-20T02:00:00+00:00":0.02
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":0.02,
-                      "2022-04-20T01:00:00+00:00":0.02,
-                      "2022-04-20T02:00:00+00:00":0.02
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":0.02,
-                      "2022-04-20T01:00:00+00:00":0.02,
-                      "2022-04-20T02:00:00+00:00":0.02
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          }
-       }
+  "temporals": {
+    "t": [
+      "2022-04-20T00:00:00+00:00",
+      "2022-04-20T01:00:00+00:00",
+      "2022-04-20T02:00:00+00:00"
     ],
-    "node_delay":[
-       [
-          "delay_source",
-          "dh_source",
-          2,
-          0,
-          1000
-       ]
-    ],
-    "node_histories":{
-       "dh_source":{
-          "node":"dh_source",
-          "steps":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":1,
-                      "2022-04-20T01:00:00+00:00":1
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":1,
-                      "2022-04-20T01:00:00+00:00":1
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":1,
-                      "2022-04-20T01:00:00+00:00":1
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
+    "dtf": 1.0,
+    "is_variable_dt": false,
+    "variable_dt": [],
+    "ts_format": "yyyy-mm-ddTHH:MM:SSzzzz"
+  },
+  "setup": {
+    "contains_reserves": true,
+    "contains_online": true,
+    "contains_states": true,
+    "contains_piecewise_eff": true,
+    "contains_risk": true,
+    "contains_diffusion": true,
+    "contains_delay": false,
+    "contains_markets": true,
+    "reserve_realisation": true,
+    "use_market_bids": true,
+    "common_timesteps": 2,
+    "common_scenario_name": "s_all",
+    "use_node_dummy_variables": true,
+    "use_ramp_dummy_variables": true,
+    "node_dummy_variable_cost": 10000.0,
+    "ramp_dummy_variable_cost": 10000.0
+  },
+  "processes": {
+    "ngchp": {
+      "name": "ngchp",
+      "groups": [
+        "p1"
+      ],
+      "conversion": 1,
+      "is_cf": false,
+      "is_cf_fix": false,
+      "is_online": true,
+      "is_res": true,
+      "eff": 0.9,
+      "load_min": 0.3,
+      "load_max": 1.0,
+      "start_cost": 0.0,
+      "min_online": 4,
+      "min_offline": 3,
+      "max_online": 0,
+      "max_offline": 0,
+      "initial_state": true,
+      "is_scenario_independent": true,
+      "topos": [
+        {
+          "source": "ng",
+          "sink": "ngchp",
+          "capacity": 20.0,
+          "vom_cost": 3.0,
+          "ramp_up": 0.5,
+          "ramp_down": 0.5,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [],
+            "index": {}
           }
-       }
-    },
-    "markets":{
-       "npe":{
-          "name":"npe",
-          "m_type":"energy",
-          "node":"elc",
-          "processgroup":"p1",
-          "direction":"none",
-          "realisation":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "reserve_type":"none",
-          "is_bid":true,
-          "is_limited":false,
-          "min_bid":0.0,
-          "max_bid":0.0,
-          "fee":0.0,
-          "price":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":48,
-                      "2022-04-20T01:00:00+00:00":60,
-                      "2022-04-20T02:00:00+00:00":58
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":48,
-                      "2022-04-20T01:00:00+00:00":60,
-                      "2022-04-20T02:00:00+00:00":87
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":48,
-                      "2022-04-20T01:00:00+00:00":60,
-                      "2022-04-20T02:00:00+00:00":89
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          },
-          "up_price":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":52.800000000000004,
-                      "2022-04-20T01:00:00+00:00":66,
-                      "2022-04-20T02:00:00+00:00":63.800000000000004
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":52.800000000000004,
-                      "2022-04-20T01:00:00+00:00":66,
-                      "2022-04-20T02:00:00+00:00":95.7
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":52.800000000000004,
-                      "2022-04-20T01:00:00+00:00":66,
-                      "2022-04-20T02:00:00+00:00":95.7
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          },
-          "down_price":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":43.2,
-                      "2022-04-20T01:00:00+00:00":54,
-                      "2022-04-20T02:00:00+00:00":52.2
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":43.2,
-                      "2022-04-20T01:00:00+00:00":54,
-                      "2022-04-20T02:00:00+00:00":78.3
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":43.2,
-                      "2022-04-20T01:00:00+00:00":54,
-                      "2022-04-20T02:00:00+00:00":78.3
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          },
-          "reserve_activation_price":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "fixed":[
-
-          ]
-       },
-       "fcr_up":{
-          "name":"fcr_up",
-          "m_type":"reserve",
-          "node":"elc_res",
-          "processgroup":"p1",
-          "direction":"res_up",
-          "realisation":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":0.27,
-                      "2022-04-20T01:00:00+00:00":0.27,
-                      "2022-04-20T02:00:00+00:00":0.27
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":0.27,
-                      "2022-04-20T01:00:00+00:00":0.27,
-                      "2022-04-20T02:00:00+00:00":0.29
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":0.27,
-                      "2022-04-20T01:00:00+00:00":0.27,
-                      "2022-04-20T02:00:00+00:00":0.31
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          },
-          "reserve_type":"slow",
-          "is_bid":true,
-          "is_limited":false,
-          "min_bid":0.0,
-          "max_bid":0.0,
-          "fee":0.0,
-          "price":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":4,
-                      "2022-04-20T01:00:00+00:00":56,
-                      "2022-04-20T02:00:00+00:00":44
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":4,
-                      "2022-04-20T01:00:00+00:00":56,
-                      "2022-04-20T02:00:00+00:00":52.8
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":4,
-                      "2022-04-20T01:00:00+00:00":56,
-                      "2022-04-20T02:00:00+00:00":55
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          },
-          "up_price":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "down_price":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
-          },
-          "reserve_activation_price":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":1,
-                      "2022-04-20T01:00:00+00:00":2,
-                      "2022-04-20T02:00:00+00:00":3
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":1,
-                      "2022-04-20T01:00:00+00:00":2,
-                      "2022-04-20T02:00:00+00:00":3
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":1,
-                      "2022-04-20T01:00:00+00:00":2,
-                      "2022-04-20T02:00:00+00:00":3
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
-          },
-          "fixed":[
-
-          ]
-       }
-    },
-    "groups":{
-       "p1":{
-          "name":"p1",
-          "g_type":"Process",
-          "members":[
-             "ngchp",
-             "hp1",
-             "p2x1"
-          ]
-       },
-       "elc_res":{
-          "name":"elc_res",
-          "g_type":"Node",
-          "members":[
-             "elc"
-          ]
-       }
-    },
-    "scenarios":{
-       "s1":0.4,
-       "s2":0.3,
-       "s3":0.3
-    },
-    "reserve_type":{
-       "slow":1.0
-    },
-    "risk":{
-       "alfa":0.1,
-       "beta":0.2
-    },
-    "inflow_blocks":{
-       "b1":{
-          "name":"b1",
-          "node":"dh_sto",
-          "start_time":"2022-04-20T00:00:00+00:00",
-          "data":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":-2,
-                      "2022-04-20T01:00:00+00:00":1,
-                      "2022-04-20T02:00:00+00:00":2
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":-3,
-                      "2022-04-20T01:00:00+00:00":2,
-                      "2022-04-20T02:00:00+00:00":2
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":-4,
-                      "2022-04-20T01:00:00+00:00":3,
-                      "2022-04-20T02:00:00+00:00":2
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
+        },
+        {
+          "source": "ngchp",
+          "sink": "dh",
+          "capacity": 10.0,
+          "vom_cost": 0.0,
+          "ramp_up": 0.5,
+          "ramp_down": 0.5,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [],
+            "index": {}
           }
-       }
+        },
+        {
+          "source": "ngchp",
+          "sink": "elc",
+          "capacity": 8.0,
+          "vom_cost": 0.0,
+          "ramp_up": 0.5,
+          "ramp_down": 0.5,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [],
+            "index": {}
+          }
+        }
+      ],
+      "cf": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ts": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ops": [
+        "op1",
+        "op2",
+        "op3",
+        "op4",
+        "op5"
+      ],
+      "eff_fun": [
+        [
+          0.4,
+          0.8
+        ],
+        [
+          0.6,
+          0.78
+        ],
+        [
+          0.8,
+          0.75
+        ],
+        [
+          0.9,
+          0.7
+        ],
+        [
+          1,
+          0.65
+        ]
+      ]
     },
-    "bid_slots":{
-       "npe":{
-          "market":"npe",
-          "time_steps":[
-             "2022-04-20T00:00:00+00:00",
-             "2022-04-20T01:00:00+00:00",
-             "2022-04-20T02:00:00+00:00"
-          ],
-          "slots":[
-             "p0",
-             "p1",
-             "p2",
-             "p3"
-          ],
-          "prices":{
-             "(\"2022-04-20T00:00:00+00:00\", \"p0\")":45.0,
-             "(\"2022-04-20T01:00:00+00:00\", \"p0\")":58.0,
-             "(\"2022-04-20T02:00:00+00:00\", \"p0\")":55.0,
-             "(\"2022-04-20T00:00:00+00:00\", \"p1\")":45.0,
-             "(\"2022-04-20T01:00:00+00:00\", \"p1\")":58.0,
-             "(\"2022-04-20T02:00:00+00:00\", \"p1\")":65.0,
-             "(\"2022-04-20T00:00:00+00:00\", \"p2\")":50.0,
-             "(\"2022-04-20T01:00:00+00:00\", \"p2\")":62.0,
-             "(\"2022-04-20T02:00:00+00:00\", \"p2\")":88.0,
-             "(\"2022-04-20T00:00:00+00:00\", \"p3\")":50.0,
-             "(\"2022-04-20T01:00:00+00:00\", \"p3\")":62.0,
-             "(\"2022-04-20T02:00:00+00:00\", \"p3\")":91.0
+    "hp1": {
+      "name": "hp1",
+      "groups": [
+        "p1"
+      ],
+      "conversion": 1,
+      "is_cf": false,
+      "is_cf_fix": false,
+      "is_online": false,
+      "is_res": true,
+      "eff": 3.0,
+      "load_min": 0.0,
+      "load_max": 1.0,
+      "start_cost": 0.0,
+      "min_online": 0,
+      "min_offline": 0,
+      "max_online": 0,
+      "max_offline": 0,
+      "initial_state": false,
+      "is_scenario_independent": false,
+      "topos": [
+        {
+          "source": "elc",
+          "sink": "hp1",
+          "capacity": 5.0,
+          "vom_cost": 15.0,
+          "ramp_up": 0.5,
+          "ramp_down": 0.5,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [
+              {
+                "scenario": "s1",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": 5,
+                  "2022-04-20T01:00:00+00:00": 4.285714285714286,
+                  "2022-04-20T02:00:00+00:00": 4.285714285714286
+                }
+              },
+              {
+                "scenario": "s2",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": 5,
+                  "2022-04-20T01:00:00+00:00": 4.285714285714286,
+                  "2022-04-20T02:00:00+00:00": 4.285714285714286
+                }
+              },
+              {
+                "scenario": "s3",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": 5,
+                  "2022-04-20T01:00:00+00:00": 4.28571428571429,
+                  "2022-04-20T02:00:00+00:00": 4.28571428571429
+                }
+              }
+            ],
+            "index": {
+              "s1": 1,
+              "s2": 2,
+              "s3": 3
+            }
+          }
+        },
+        {
+          "source": "hp1",
+          "sink": "dh",
+          "capacity": 15.0,
+          "vom_cost": 0.5,
+          "ramp_up": 0.5,
+          "ramp_down": 0.5,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [],
+            "index": {}
+          }
+        }
+      ],
+      "cf": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ts": {
+        "ts_data": [
+          {
+            "scenario": "s1",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 3,
+              "2022-04-20T01:00:00+00:00": 3.5,
+              "2022-04-20T02:00:00+00:00": 3.5
+            }
           },
-          "market_price_allocation":{
-             "(\"s1\", \"2022-04-20T00:00:00+00:00\")":[
-                "p1",
-                "p2"
-             ],
-             "(\"s2\", \"2022-04-20T00:00:00+00:00\")":[
-                "p1",
-                "p2"
-             ],
-             "(\"s3\", \"2022-04-20T00:00:00+00:00\")":[
-                "p1",
-                "p2"
-             ],
-             "(\"s1\", \"2022-04-20T01:00:00+00:00\")":[
-                "p1",
-                "p2"
-             ],
-             "(\"s2\", \"2022-04-20T01:00:00+00:00\")":[
-                "p1",
-                "p2"
-             ],
-             "(\"s3\", \"2022-04-20T01:00:00+00:00\")":[
-                "p1",
-                "p2"
-             ],
-             "(\"s1\", \"2022-04-20T02:00:00+00:00\")":[
-                "p0",
-                "p1"
-             ],
-             "(\"s2\", \"2022-04-20T02:00:00+00:00\")":[
-                "p1",
-                "p2"
-             ],
-             "(\"s3\", \"2022-04-20T02:00:00+00:00\")":[
-                "p2",
-                "p3"
-             ]
+          {
+            "scenario": "s2",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 3,
+              "2022-04-20T01:00:00+00:00": 3.5,
+              "2022-04-20T02:00:00+00:00": 3.5
+            }
+          },
+          {
+            "scenario": "s3",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 3,
+              "2022-04-20T01:00:00+00:00": 3.5,
+              "2022-04-20T02:00:00+00:00": 3.5
+            }
           }
-       }
+        ],
+        "index": {
+          "s1": 1,
+          "s2": 2,
+          "s3": 3
+        }
+      },
+      "eff_ops": [],
+      "eff_fun": []
     },
-    "gen_constraints":{
-       "c1":{
-          "name":"c1",
-          "gc_type":"eq",
-          "is_setpoint":false,
-          "penalty":0.0,
-          "factors":[
-             {
-                "var_type":"flow",
-                "var_tuple":[
-                   "ngchp",
-                   "elc"
-                ],
-                "data":{
-                   "ts_data":[
-                      {
-                         "scenario":"s1",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":1,
-                            "2022-04-20T01:00:00+00:00":1,
-                            "2022-04-20T02:00:00+00:00":1
-                         }
-                      },
-                      {
-                         "scenario":"s2",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":1,
-                            "2022-04-20T01:00:00+00:00":1,
-                            "2022-04-20T02:00:00+00:00":1
-                         }
-                      },
-                      {
-                         "scenario":"s3",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":1,
-                            "2022-04-20T01:00:00+00:00":1,
-                            "2022-04-20T02:00:00+00:00":1
-                         }
-                      }
-                   ],
-                   "index":{
-                      "s1":1,
-                      "s2":2,
-                      "s3":3
-                   }
-                }
-             },
-             {
-                "var_type":"flow",
-                "var_tuple":[
-                   "ngchp",
-                   "dh"
-                ],
-                "data":{
-                   "ts_data":[
-                      {
-                         "scenario":"s1",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":-0.8,
-                            "2022-04-20T01:00:00+00:00":-0.8,
-                            "2022-04-20T02:00:00+00:00":-0.8
-                         }
-                      },
-                      {
-                         "scenario":"s2",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":-0.8,
-                            "2022-04-20T01:00:00+00:00":-0.8,
-                            "2022-04-20T02:00:00+00:00":-0.8
-                         }
-                      },
-                      {
-                         "scenario":"s3",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":-0.8,
-                            "2022-04-20T01:00:00+00:00":-0.8,
-                            "2022-04-20T02:00:00+00:00":-0.8
-                         }
-                      }
-                   ],
-                   "index":{
-                      "s1":1,
-                      "s2":2,
-                      "s3":3
-                   }
-                }
-             }
-          ],
-          "constant":{
-             "ts_data":[
-                {
-                   "scenario":"s1",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":0,
-                      "2022-04-20T01:00:00+00:00":0,
-                      "2022-04-20T02:00:00+00:00":0
-                   }
-                },
-                {
-                   "scenario":"s2",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":0,
-                      "2022-04-20T01:00:00+00:00":0,
-                      "2022-04-20T02:00:00+00:00":0
-                   }
-                },
-                {
-                   "scenario":"s3",
-                   "series":{
-                      "2022-04-20T00:00:00+00:00":0,
-                      "2022-04-20T01:00:00+00:00":0,
-                      "2022-04-20T02:00:00+00:00":0
-                   }
-                }
-             ],
-             "index":{
-                "s1":1,
-                "s2":2,
-                "s3":3
-             }
+    "p2x1": {
+      "name": "p2x1",
+      "groups": [
+        "p1"
+      ],
+      "conversion": 1,
+      "is_cf": false,
+      "is_cf_fix": false,
+      "is_online": false,
+      "is_res": true,
+      "eff": 0.7,
+      "load_min": 0.0,
+      "load_max": 1.0,
+      "start_cost": 0.0,
+      "min_online": 0,
+      "min_offline": 0,
+      "max_online": 0,
+      "max_offline": 0,
+      "initial_state": false,
+      "is_scenario_independent": false,
+      "topos": [
+        {
+          "source": "elc",
+          "sink": "p2x1",
+          "capacity": 10.0,
+          "vom_cost": 15.0,
+          "ramp_up": 1.0,
+          "ramp_down": 1.0,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [],
+            "index": {}
           }
-       },
-       "c2":{
-          "name":"c2",
-          "gc_type":"st",
-          "is_setpoint":true,
-          "penalty":1.0,
-          "factors":[
-             {
-                "var_type":"state",
-                "var_tuple":[
-                   "dh_sto",
-                   ""
-                ],
-                "data":{
-                   "ts_data":[
-                      {
-                         "scenario":"s1",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":300,
-                            "2022-04-20T01:00:00+00:00":300,
-                            "2022-04-20T02:00:00+00:00":300
-                         }
-                      },
-                      {
-                         "scenario":"s2",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":300,
-                            "2022-04-20T01:00:00+00:00":300,
-                            "2022-04-20T02:00:00+00:00":300
-                         }
-                      },
-                      {
-                         "scenario":"s3",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":300,
-                            "2022-04-20T01:00:00+00:00":300,
-                            "2022-04-20T02:00:00+00:00":300
-                         }
-                      }
-                   ],
-                   "index":{
-                      "s1":1,
-                      "s2":2,
-                      "s3":3
-                   }
-                }
-             }
-          ],
-          "constant":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
+        },
+        {
+          "source": "p2x1",
+          "sink": "h2",
+          "capacity": 7.0,
+          "vom_cost": 1.0,
+          "ramp_up": 1.0,
+          "ramp_down": 1.0,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [],
+            "index": {}
           }
-       },
-       "c3":{
-          "name":"c3",
-          "gc_type":"gt",
-          "is_setpoint":true,
-          "penalty":1.0,
-          "factors":[
-             {
-                "var_type":"state",
-                "var_tuple":[
-                   "dh_sto",
-                   ""
-                ],
-                "data":{
-                   "ts_data":[
-                      {
-                         "scenario":"s1",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":256,
-                            "2022-04-20T01:00:00+00:00":256,
-                            "2022-04-20T02:00:00+00:00":256
-                         }
-                      },
-                      {
-                         "scenario":"s2",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":256,
-                            "2022-04-20T01:00:00+00:00":256,
-                            "2022-04-20T02:00:00+00:00":256
-                         }
-                      },
-                      {
-                         "scenario":"s3",
-                         "series":{
-                            "2022-04-20T00:00:00+00:00":256,
-                            "2022-04-20T01:00:00+00:00":256,
-                            "2022-04-20T02:00:00+00:00":256
-                         }
-                      }
-                   ],
-                   "index":{
-                      "s1":1,
-                      "s2":2,
-                      "s3":3
-                   }
-                }
-             }
-          ],
-          "constant":{
-             "ts_data":[
-
-             ],
-             "index":{
-
-             }
+        }
+      ],
+      "cf": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ts": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ops": [],
+      "eff_fun": []
+    },
+    "pv1": {
+      "name": "pv1",
+      "groups": [],
+      "conversion": 1,
+      "is_cf": true,
+      "is_cf_fix": true,
+      "is_online": false,
+      "is_res": false,
+      "eff": 1.0,
+      "load_min": 0.0,
+      "load_max": 1.0,
+      "start_cost": 0.0,
+      "min_online": 0,
+      "min_offline": 0,
+      "max_online": 0,
+      "max_offline": 0,
+      "initial_state": false,
+      "is_scenario_independent": false,
+      "topos": [
+        {
+          "source": "pv1",
+          "sink": "elc",
+          "capacity": 5.0,
+          "vom_cost": 0.5,
+          "ramp_up": 1.0,
+          "ramp_down": 1.0,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [],
+            "index": {}
           }
-       }
+        }
+      ],
+      "cf": {
+        "ts_data": [
+          {
+            "scenario": "s1",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 0,
+              "2022-04-20T01:00:00+00:00": 0.4,
+              "2022-04-20T02:00:00+00:00": 0.5
+            }
+          },
+          {
+            "scenario": "s2",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 0,
+              "2022-04-20T01:00:00+00:00": 0.4,
+              "2022-04-20T02:00:00+00:00": 0.5
+            }
+          },
+          {
+            "scenario": "s3",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 0,
+              "2022-04-20T01:00:00+00:00": 0.4,
+              "2022-04-20T02:00:00+00:00": 0.5
+            }
+          }
+        ],
+        "index": {
+          "s1": 1,
+          "s2": 2,
+          "s3": 3
+        }
+      },
+      "eff_ts": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ops": [],
+      "eff_fun": []
+    },
+    "dh_tra": {
+      "name": "dh_tra",
+      "groups": [],
+      "conversion": 2,
+      "is_cf": false,
+      "is_cf_fix": false,
+      "is_online": false,
+      "is_res": false,
+      "eff": 0.99,
+      "load_min": 0.0,
+      "load_max": 1.0,
+      "start_cost": 0.0,
+      "min_online": 0,
+      "min_offline": 0,
+      "max_online": 0,
+      "max_offline": 0,
+      "initial_state": false,
+      "is_scenario_independent": false,
+      "topos": [
+        {
+          "source": "dh",
+          "sink": "dh2",
+          "capacity": 20.0,
+          "vom_cost": 0.0,
+          "ramp_up": 1.0,
+          "ramp_down": 1.0,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [],
+            "index": {}
+          }
+        }
+      ],
+      "cf": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ts": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ops": [],
+      "eff_fun": []
+    },
+    "dh_sto_charge": {
+      "name": "dh_sto_charge",
+      "groups": [],
+      "conversion": 1,
+      "is_cf": false,
+      "is_cf_fix": false,
+      "is_online": false,
+      "is_res": false,
+      "eff": 0.99,
+      "load_min": 0.0,
+      "load_max": 1.0,
+      "start_cost": 0.0,
+      "min_online": 0,
+      "min_offline": 0,
+      "max_online": 0,
+      "max_offline": 0,
+      "initial_state": false,
+      "is_scenario_independent": false,
+      "topos": [
+        {
+          "source": "dh",
+          "sink": "dh_sto_charge",
+          "capacity": 20.0,
+          "vom_cost": 0.0,
+          "ramp_up": 1.0,
+          "ramp_down": 1.0,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [],
+            "index": {}
+          }
+        },
+        {
+          "source": "dh_sto_charge",
+          "sink": "dh_sto",
+          "capacity": 20.0,
+          "vom_cost": 0.0,
+          "ramp_up": 1.0,
+          "ramp_down": 1.0,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [],
+            "index": {}
+          }
+        }
+      ],
+      "cf": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ts": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ops": [],
+      "eff_fun": []
+    },
+    "dh_sto_discharge": {
+      "name": "dh_sto_discharge",
+      "groups": [],
+      "conversion": 1,
+      "is_cf": false,
+      "is_cf_fix": false,
+      "is_online": false,
+      "is_res": false,
+      "eff": 0.99,
+      "load_min": 0.0,
+      "load_max": 1.0,
+      "start_cost": 0.0,
+      "min_online": 0,
+      "min_offline": 0,
+      "max_online": 0,
+      "max_offline": 0,
+      "initial_state": false,
+      "is_scenario_independent": false,
+      "topos": [
+        {
+          "source": "dh_sto",
+          "sink": "dh_sto_discharge",
+          "capacity": 20.0,
+          "vom_cost": 0.0,
+          "ramp_up": 1.0,
+          "ramp_down": 1.0,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [],
+            "index": {}
+          }
+        },
+        {
+          "source": "dh_sto_discharge",
+          "sink": "dh",
+          "capacity": 20.0,
+          "vom_cost": 0.0,
+          "ramp_up": 1.0,
+          "ramp_down": 1.0,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [],
+            "index": {}
+          }
+        }
+      ],
+      "cf": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ts": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ops": [],
+      "eff_fun": []
+    },
+    "dh_source_out": {
+      "name": "dh_source_out",
+      "groups": [],
+      "conversion": 2,
+      "is_cf": false,
+      "is_cf_fix": false,
+      "is_online": false,
+      "is_res": false,
+      "eff": 1.0,
+      "load_min": 0.0,
+      "load_max": 1.0,
+      "start_cost": 0.0,
+      "min_online": 0,
+      "min_offline": 0,
+      "max_online": 0,
+      "max_offline": 0,
+      "initial_state": false,
+      "is_scenario_independent": false,
+      "topos": [
+        {
+          "source": "dh_source_out",
+          "sink": "dh",
+          "capacity": 1000.0,
+          "vom_cost": 0.0,
+          "ramp_up": 1.0,
+          "ramp_down": 1.0,
+          "initial_load": 0.6,
+          "initial_flow": 0.6,
+          "cap_ts": {
+            "ts_data": [],
+            "index": {}
+          }
+        }
+      ],
+      "cf": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ts": {
+        "ts_data": [],
+        "index": {}
+      },
+      "eff_ops": [],
+      "eff_fun": []
     }
- }
+  },
+  "nodes": {
+    "ng": {
+      "name": "ng",
+      "groups": [],
+      "is_commodity": true,
+      "is_market": false,
+      "is_state": false,
+      "is_res": false,
+      "is_inflow": false,
+      "state": null,
+      "cost": {
+        "ts_data": [
+          {
+            "scenario": "s1",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 12,
+              "2022-04-20T01:00:00+00:00": 12,
+              "2022-04-20T02:00:00+00:00": 12
+            }
+          },
+          {
+            "scenario": "s2",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 12,
+              "2022-04-20T01:00:00+00:00": 12,
+              "2022-04-20T02:00:00+00:00": 12
+            }
+          },
+          {
+            "scenario": "s3",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 12,
+              "2022-04-20T01:00:00+00:00": 12,
+              "2022-04-20T02:00:00+00:00": 12
+            }
+          }
+        ],
+        "index": {
+          "s1": 1,
+          "s2": 2,
+          "s3": 3
+        }
+      },
+      "inflow": {
+        "TimeSeriesData": {
+          "ts_data": [],
+          "index": {}
+        }
+      }
+    },
+    "elc": {
+      "name": "elc",
+      "groups": [
+        "elc_res"
+      ],
+      "is_commodity": false,
+      "is_market": false,
+      "is_state": false,
+      "is_res": true,
+      "is_inflow": false,
+      "state": null,
+      "cost": {
+        "ts_data": [],
+        "index": {}
+      },
+      "inflow": {
+        "TimeSeriesData": {
+          "ts_data": [],
+          "index": {}
+        }
+      }
+    },
+    "dh": {
+      "name": "dh",
+      "groups": [],
+      "is_commodity": false,
+      "is_market": false,
+      "is_state": false,
+      "is_res": false,
+      "is_inflow": false,
+      "state": null,
+      "cost": {
+        "ts_data": [],
+        "index": {}
+      },
+      "inflow": {
+        "TimeSeriesData": {
+          "ts_data": [],
+          "index": {}
+        }
+      }
+    },
+    "h2": {
+      "name": "h2",
+      "groups": [],
+      "is_commodity": false,
+      "is_market": false,
+      "is_state": true,
+      "is_res": false,
+      "is_inflow": true,
+      "state": {
+        "in_max": 1.0,
+        "out_max": 1.0,
+        "state_loss_proportional": 0.0,
+        "state_max": 4.0,
+        "state_min": 0.0,
+        "initial_state": 0.0,
+        "is_scenario_independent": false,
+        "is_temp": false,
+        "t_e_conversion": 1.0,
+        "residual_value": 0.0
+      },
+      "cost": {
+        "ts_data": [],
+        "index": {}
+      },
+      "inflow": {
+        "TimeSeriesData": {
+          "ts_data": [
+            {
+              "scenario": "s1",
+              "series": {
+                "2022-04-20T00:00:00+00:00": -5,
+                "2022-04-20T01:00:00+00:00": -5,
+                "2022-04-20T02:00:00+00:00": -6
+              }
+            },
+            {
+              "scenario": "s2",
+              "series": {
+                "2022-04-20T00:00:00+00:00": -5,
+                "2022-04-20T01:00:00+00:00": -5,
+                "2022-04-20T02:00:00+00:00": -6
+              }
+            },
+            {
+              "scenario": "s3",
+              "series": {
+                "2022-04-20T00:00:00+00:00": -5,
+                "2022-04-20T01:00:00+00:00": -5,
+                "2022-04-20T02:00:00+00:00": -6
+              }
+            }
+          ],
+          "index": {
+            "s1": 1,
+            "s2": 2,
+            "s3": 3
+          }
+        }
+      }
+    },
+    "dh2": {
+      "name": "dh2",
+      "groups": [],
+      "is_commodity": false,
+      "is_market": false,
+      "is_state": false,
+      "is_res": false,
+      "is_inflow": true,
+      "state": null,
+      "cost": {
+        "ts_data": [],
+        "index": {}
+      },
+      "inflow": {
+        "TimeSeriesData": {
+          "ts_data": [
+            {
+              "scenario": "s1",
+              "series": {
+                "2022-04-20T00:00:00+00:00": -5,
+                "2022-04-20T01:00:00+00:00": -5,
+                "2022-04-20T02:00:00+00:00": -4
+              }
+            },
+            {
+              "scenario": "s2",
+              "series": {
+                "2022-04-20T00:00:00+00:00": -5,
+                "2022-04-20T01:00:00+00:00": -5,
+                "2022-04-20T02:00:00+00:00": -4
+              }
+            },
+            {
+              "scenario": "s3",
+              "series": {
+                "2022-04-20T00:00:00+00:00": -5,
+                "2022-04-20T01:00:00+00:00": -5,
+                "2022-04-20T02:00:00+00:00": -4
+              }
+            }
+          ],
+          "index": {
+            "s1": 1,
+            "s2": 2,
+            "s3": 3
+          }
+        }
+      }
+    },
+    "dh_sto": {
+      "name": "dh_sto",
+      "groups": [],
+      "is_commodity": false,
+      "is_market": false,
+      "is_state": true,
+      "is_res": false,
+      "is_inflow": false,
+      "state": {
+        "in_max": 20.0,
+        "out_max": 20.0,
+        "state_loss_proportional": 0.0,
+        "state_max": 393.15,
+        "state_min": 330.15,
+        "initial_state": 373.15,
+        "is_scenario_independent": false,
+        "is_temp": true,
+        "t_e_conversion": 0.23277777777777803,
+        "residual_value": 20.0
+      },
+      "cost": {
+        "ts_data": [],
+        "index": {}
+      },
+      "inflow": {
+        "TimeSeriesData": {
+          "ts_data": [],
+          "index": {}
+        }
+      }
+    },
+    "ambience": {
+      "name": "ambience",
+      "groups": [],
+      "is_commodity": false,
+      "is_market": false,
+      "is_state": true,
+      "is_res": false,
+      "is_inflow": true,
+      "state": {
+        "in_max": 100000000.0,
+        "out_max": 100000000.0,
+        "state_loss_proportional": 0.0,
+        "state_max": 300.15,
+        "state_min": 253.15,
+        "initial_state": 273.15,
+        "is_scenario_independent": false,
+        "is_temp": true,
+        "t_e_conversion": 10000000.0,
+        "residual_value": 0.0
+      },
+      "cost": {
+        "ts_data": [],
+        "index": {}
+      },
+      "inflow": {
+        "TimeSeriesData": {
+          "ts_data": [
+            {
+              "scenario": "s1",
+              "series": {
+                "2022-04-20T00:00:00+00:00": -1,
+                "2022-04-20T01:00:00+00:00": 0,
+                "2022-04-20T02:00:00+00:00": -2
+              }
+            },
+            {
+              "scenario": "s2",
+              "series": {
+                "2022-04-20T00:00:00+00:00": -1,
+                "2022-04-20T01:00:00+00:00": 0,
+                "2022-04-20T02:00:00+00:00": 0
+              }
+            },
+            {
+              "scenario": "s3",
+              "series": {
+                "2022-04-20T00:00:00+00:00": -1,
+                "2022-04-20T01:00:00+00:00": 0,
+                "2022-04-20T02:00:00+00:00": 0
+              }
+            }
+          ],
+          "index": {
+            "s1": 1,
+            "s2": 2,
+            "s3": 3
+          }
+        }
+      }
+    },
+    "delay_source": {
+      "name": "delay_source",
+      "groups": [],
+      "is_commodity": false,
+      "is_market": false,
+      "is_state": false,
+      "is_res": false,
+      "is_inflow": true,
+      "state": null,
+      "cost": {
+        "ts_data": [],
+        "index": {}
+      },
+      "inflow": {
+        "TimeSeriesData": {
+          "ts_data": [
+            {
+              "scenario": "s1",
+              "series": {
+                "2022-04-20T00:00:00+00:00": 1,
+                "2022-04-20T01:00:00+00:00": 1,
+                "2022-04-20T02:00:00+00:00": 2
+              }
+            },
+            {
+              "scenario": "s2",
+              "series": {
+                "2022-04-20T00:00:00+00:00": 1,
+                "2022-04-20T01:00:00+00:00": 1,
+                "2022-04-20T02:00:00+00:00": 2
+              }
+            },
+            {
+              "scenario": "s3",
+              "series": {
+                "2022-04-20T00:00:00+00:00": 1,
+                "2022-04-20T01:00:00+00:00": 1,
+                "2022-04-20T02:00:00+00:00": 2
+              }
+            }
+          ],
+          "index": {
+            "s1": 1,
+            "s2": 2,
+            "s3": 3
+          }
+        }
+      }
+    },
+    "dh_source": {
+      "name": "dh_source",
+      "groups": [],
+      "is_commodity": false,
+      "is_market": false,
+      "is_state": true,
+      "is_res": false,
+      "is_inflow": false,
+      "state": {
+        "in_max": 1000.0,
+        "out_max": 1000.0,
+        "state_loss_proportional": 0.9,
+        "state_max": 1000.0,
+        "state_min": 0.0,
+        "initial_state": 0.0,
+        "is_scenario_independent": false,
+        "is_temp": false,
+        "t_e_conversion": 1.0,
+        "residual_value": 0.0
+      },
+      "cost": {
+        "ts_data": [],
+        "index": {}
+      },
+      "inflow": {
+        "TimeSeriesData": {
+          "ts_data": [],
+          "index": {}
+        }
+      }
+    }
+  },
+  "node_diffusion": [
+    {
+      "node1": "dh_sto",
+      "node2": "ambience",
+      "coefficient": {
+        "ts_data": [
+          {
+            "scenario": "s1",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 0.02,
+              "2022-04-20T01:00:00+00:00": 0.02,
+              "2022-04-20T02:00:00+00:00": 0.02
+            }
+          },
+          {
+            "scenario": "s2",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 0.02,
+              "2022-04-20T01:00:00+00:00": 0.02,
+              "2022-04-20T02:00:00+00:00": 0.02
+            }
+          },
+          {
+            "scenario": "s3",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 0.02,
+              "2022-04-20T01:00:00+00:00": 0.02,
+              "2022-04-20T02:00:00+00:00": 0.02
+            }
+          }
+        ],
+        "index": {
+          "s1": 1,
+          "s2": 2,
+          "s3": 3
+        }
+      }
+    }
+  ],
+  "node_delay": [
+    [
+      "delay_source",
+      "dh_source",
+      2,
+      0,
+      1000
+    ]
+  ],
+  "node_histories": {
+    "dh_source": {
+      "node": "dh_source",
+      "steps": {
+        "ts_data": [
+          {
+            "scenario": "s1",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 1,
+              "2022-04-20T01:00:00+00:00": 1
+            }
+          },
+          {
+            "scenario": "s2",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 1,
+              "2022-04-20T01:00:00+00:00": 1
+            }
+          },
+          {
+            "scenario": "s3",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 1,
+              "2022-04-20T01:00:00+00:00": 1
+            }
+          }
+        ],
+        "index": {
+          "s1": 1,
+          "s2": 2,
+          "s3": 3
+        }
+      }
+    }
+  },
+  "markets": {
+    "npe": {
+      "name": "npe",
+      "m_type": "energy",
+      "node": "elc",
+      "processgroup": "p1",
+      "direction": "none",
+      "realisation": {
+        "ts_data": [],
+        "index": {}
+      },
+      "reserve_type": "none",
+      "is_bid": true,
+      "is_limited": false,
+      "min_bid": 0.0,
+      "max_bid": 0.0,
+      "fee": 0.0,
+      "price": {
+        "ts_data": [
+          {
+            "scenario": "s1",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 48,
+              "2022-04-20T01:00:00+00:00": 60,
+              "2022-04-20T02:00:00+00:00": 58
+            }
+          },
+          {
+            "scenario": "s2",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 48,
+              "2022-04-20T01:00:00+00:00": 60,
+              "2022-04-20T02:00:00+00:00": 87
+            }
+          },
+          {
+            "scenario": "s3",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 48,
+              "2022-04-20T01:00:00+00:00": 60,
+              "2022-04-20T02:00:00+00:00": 89
+            }
+          }
+        ],
+        "index": {
+          "s1": 1,
+          "s2": 2,
+          "s3": 3
+        }
+      },
+      "up_price": {
+        "ts_data": [
+          {
+            "scenario": "s1",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 52.800000000000004,
+              "2022-04-20T01:00:00+00:00": 66,
+              "2022-04-20T02:00:00+00:00": 63.800000000000004
+            }
+          },
+          {
+            "scenario": "s2",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 52.800000000000004,
+              "2022-04-20T01:00:00+00:00": 66,
+              "2022-04-20T02:00:00+00:00": 95.7
+            }
+          },
+          {
+            "scenario": "s3",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 52.800000000000004,
+              "2022-04-20T01:00:00+00:00": 66,
+              "2022-04-20T02:00:00+00:00": 95.7
+            }
+          }
+        ],
+        "index": {
+          "s1": 1,
+          "s2": 2,
+          "s3": 3
+        }
+      },
+      "down_price": {
+        "ts_data": [
+          {
+            "scenario": "s1",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 43.2,
+              "2022-04-20T01:00:00+00:00": 54,
+              "2022-04-20T02:00:00+00:00": 52.2
+            }
+          },
+          {
+            "scenario": "s2",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 43.2,
+              "2022-04-20T01:00:00+00:00": 54,
+              "2022-04-20T02:00:00+00:00": 78.3
+            }
+          },
+          {
+            "scenario": "s3",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 43.2,
+              "2022-04-20T01:00:00+00:00": 54,
+              "2022-04-20T02:00:00+00:00": 78.3
+            }
+          }
+        ],
+        "index": {
+          "s1": 1,
+          "s2": 2,
+          "s3": 3
+        }
+      },
+      "reserve_activation_price": {
+        "ts_data": [],
+        "index": {}
+      },
+      "fixed": []
+    },
+    "fcr_up": {
+      "name": "fcr_up",
+      "m_type": "reserve",
+      "node": "elc_res",
+      "processgroup": "p1",
+      "direction": "res_up",
+      "realisation": {
+        "ts_data": [
+          {
+            "scenario": "s1",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 0.27,
+              "2022-04-20T01:00:00+00:00": 0.27,
+              "2022-04-20T02:00:00+00:00": 0.27
+            }
+          },
+          {
+            "scenario": "s2",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 0.27,
+              "2022-04-20T01:00:00+00:00": 0.27,
+              "2022-04-20T02:00:00+00:00": 0.29
+            }
+          },
+          {
+            "scenario": "s3",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 0.27,
+              "2022-04-20T01:00:00+00:00": 0.27,
+              "2022-04-20T02:00:00+00:00": 0.31
+            }
+          }
+        ],
+        "index": {
+          "s1": 1,
+          "s2": 2,
+          "s3": 3
+        }
+      },
+      "reserve_type": "slow",
+      "is_bid": true,
+      "is_limited": false,
+      "min_bid": 0.0,
+      "max_bid": 0.0,
+      "fee": 0.0,
+      "price": {
+        "ts_data": [
+          {
+            "scenario": "s1",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 4,
+              "2022-04-20T01:00:00+00:00": 56,
+              "2022-04-20T02:00:00+00:00": 44
+            }
+          },
+          {
+            "scenario": "s2",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 4,
+              "2022-04-20T01:00:00+00:00": 56,
+              "2022-04-20T02:00:00+00:00": 52.8
+            }
+          },
+          {
+            "scenario": "s3",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 4,
+              "2022-04-20T01:00:00+00:00": 56,
+              "2022-04-20T02:00:00+00:00": 55
+            }
+          }
+        ],
+        "index": {
+          "s1": 1,
+          "s2": 2,
+          "s3": 3
+        }
+      },
+      "up_price": {
+        "ts_data": [],
+        "index": {}
+      },
+      "down_price": {
+        "ts_data": [],
+        "index": {}
+      },
+      "reserve_activation_price": {
+        "ts_data": [
+          {
+            "scenario": "s1",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 1,
+              "2022-04-20T01:00:00+00:00": 2,
+              "2022-04-20T02:00:00+00:00": 3
+            }
+          },
+          {
+            "scenario": "s2",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 1,
+              "2022-04-20T01:00:00+00:00": 2,
+              "2022-04-20T02:00:00+00:00": 3
+            }
+          },
+          {
+            "scenario": "s3",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 1,
+              "2022-04-20T01:00:00+00:00": 2,
+              "2022-04-20T02:00:00+00:00": 3
+            }
+          }
+        ],
+        "index": {
+          "s1": 1,
+          "s2": 2,
+          "s3": 3
+        }
+      },
+      "fixed": []
+    }
+  },
+  "groups": {
+    "p1": {
+      "name": "p1",
+      "g_type": "Process",
+      "members": [
+        "ngchp",
+        "hp1",
+        "p2x1"
+      ]
+    },
+    "elc_res": {
+      "name": "elc_res",
+      "g_type": "Node",
+      "members": [
+        "elc"
+      ]
+    }
+  },
+  "scenarios": {
+    "s1": 0.4,
+    "s2": 0.3,
+    "s3": 0.3
+  },
+  "reserve_type": {
+    "slow": 1.0
+  },
+  "risk": {
+    "alfa": 0.1,
+    "beta": 0.2
+  },
+  "inflow_blocks": {
+    "b1": {
+      "name": "b1",
+      "node": "dh_sto",
+      "start_time": "2022-04-20T00:00:00+00:00",
+      "data": {
+        "ts_data": [
+          {
+            "scenario": "s1",
+            "series": {
+              "2022-04-20T00:00:00+00:00": -2,
+              "2022-04-20T01:00:00+00:00": 1,
+              "2022-04-20T02:00:00+00:00": 2
+            }
+          },
+          {
+            "scenario": "s2",
+            "series": {
+              "2022-04-20T00:00:00+00:00": -3,
+              "2022-04-20T01:00:00+00:00": 2,
+              "2022-04-20T02:00:00+00:00": 2
+            }
+          },
+          {
+            "scenario": "s3",
+            "series": {
+              "2022-04-20T00:00:00+00:00": -4,
+              "2022-04-20T01:00:00+00:00": 3,
+              "2022-04-20T02:00:00+00:00": 2
+            }
+          }
+        ],
+        "index": {
+          "s1": 1,
+          "s2": 2,
+          "s3": 3
+        }
+      }
+    }
+  },
+  "bid_slots": {
+    "npe": {
+      "market": "npe",
+      "time_steps": [
+        "2022-04-20T00:00:00+00:00",
+        "2022-04-20T01:00:00+00:00",
+        "2022-04-20T02:00:00+00:00"
+      ],
+      "slots": [
+        "p0",
+        "p1",
+        "p2",
+        "p3"
+      ],
+      "prices": {
+        "(\"2022-04-20T00:00:00+00:00\", \"p0\")": 45.0,
+        "(\"2022-04-20T01:00:00+00:00\", \"p0\")": 58.0,
+        "(\"2022-04-20T02:00:00+00:00\", \"p0\")": 55.0,
+        "(\"2022-04-20T00:00:00+00:00\", \"p1\")": 45.0,
+        "(\"2022-04-20T01:00:00+00:00\", \"p1\")": 58.0,
+        "(\"2022-04-20T02:00:00+00:00\", \"p1\")": 65.0,
+        "(\"2022-04-20T00:00:00+00:00\", \"p2\")": 50.0,
+        "(\"2022-04-20T01:00:00+00:00\", \"p2\")": 62.0,
+        "(\"2022-04-20T02:00:00+00:00\", \"p2\")": 88.0,
+        "(\"2022-04-20T00:00:00+00:00\", \"p3\")": 50.0,
+        "(\"2022-04-20T01:00:00+00:00\", \"p3\")": 62.0,
+        "(\"2022-04-20T02:00:00+00:00\", \"p3\")": 91.0
+      },
+      "market_price_allocation": {
+        "(\"s1\", \"2022-04-20T00:00:00+00:00\")": [
+          "p1",
+          "p2"
+        ],
+        "(\"s2\", \"2022-04-20T00:00:00+00:00\")": [
+          "p1",
+          "p2"
+        ],
+        "(\"s3\", \"2022-04-20T00:00:00+00:00\")": [
+          "p1",
+          "p2"
+        ],
+        "(\"s1\", \"2022-04-20T01:00:00+00:00\")": [
+          "p1",
+          "p2"
+        ],
+        "(\"s2\", \"2022-04-20T01:00:00+00:00\")": [
+          "p1",
+          "p2"
+        ],
+        "(\"s3\", \"2022-04-20T01:00:00+00:00\")": [
+          "p1",
+          "p2"
+        ],
+        "(\"s1\", \"2022-04-20T02:00:00+00:00\")": [
+          "p0",
+          "p1"
+        ],
+        "(\"s2\", \"2022-04-20T02:00:00+00:00\")": [
+          "p1",
+          "p2"
+        ],
+        "(\"s3\", \"2022-04-20T02:00:00+00:00\")": [
+          "p2",
+          "p3"
+        ]
+      }
+    }
+  },
+  "gen_constraints": {
+    "c1": {
+      "name": "c1",
+      "gc_type": "eq",
+      "is_setpoint": false,
+      "penalty": 0.0,
+      "factors": [
+        {
+          "var_type": "flow",
+          "var_tuple": [
+            "ngchp",
+            "elc"
+          ],
+          "data": {
+            "ts_data": [
+              {
+                "scenario": "s1",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": 1,
+                  "2022-04-20T01:00:00+00:00": 1,
+                  "2022-04-20T02:00:00+00:00": 1
+                }
+              },
+              {
+                "scenario": "s2",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": 1,
+                  "2022-04-20T01:00:00+00:00": 1,
+                  "2022-04-20T02:00:00+00:00": 1
+                }
+              },
+              {
+                "scenario": "s3",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": 1,
+                  "2022-04-20T01:00:00+00:00": 1,
+                  "2022-04-20T02:00:00+00:00": 1
+                }
+              }
+            ],
+            "index": {
+              "s1": 1,
+              "s2": 2,
+              "s3": 3
+            }
+          }
+        },
+        {
+          "var_type": "flow",
+          "var_tuple": [
+            "ngchp",
+            "dh"
+          ],
+          "data": {
+            "ts_data": [
+              {
+                "scenario": "s1",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": -0.8,
+                  "2022-04-20T01:00:00+00:00": -0.8,
+                  "2022-04-20T02:00:00+00:00": -0.8
+                }
+              },
+              {
+                "scenario": "s2",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": -0.8,
+                  "2022-04-20T01:00:00+00:00": -0.8,
+                  "2022-04-20T02:00:00+00:00": -0.8
+                }
+              },
+              {
+                "scenario": "s3",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": -0.8,
+                  "2022-04-20T01:00:00+00:00": -0.8,
+                  "2022-04-20T02:00:00+00:00": -0.8
+                }
+              }
+            ],
+            "index": {
+              "s1": 1,
+              "s2": 2,
+              "s3": 3
+            }
+          }
+        }
+      ],
+      "constant": {
+        "ts_data": [
+          {
+            "scenario": "s1",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 0,
+              "2022-04-20T01:00:00+00:00": 0,
+              "2022-04-20T02:00:00+00:00": 0
+            }
+          },
+          {
+            "scenario": "s2",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 0,
+              "2022-04-20T01:00:00+00:00": 0,
+              "2022-04-20T02:00:00+00:00": 0
+            }
+          },
+          {
+            "scenario": "s3",
+            "series": {
+              "2022-04-20T00:00:00+00:00": 0,
+              "2022-04-20T01:00:00+00:00": 0,
+              "2022-04-20T02:00:00+00:00": 0
+            }
+          }
+        ],
+        "index": {
+          "s1": 1,
+          "s2": 2,
+          "s3": 3
+        }
+      }
+    },
+    "c2": {
+      "name": "c2",
+      "gc_type": "st",
+      "is_setpoint": true,
+      "penalty": 1.0,
+      "factors": [
+        {
+          "var_type": "state",
+          "var_tuple": [
+            "dh_sto",
+            ""
+          ],
+          "data": {
+            "ts_data": [
+              {
+                "scenario": "s1",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": 300,
+                  "2022-04-20T01:00:00+00:00": 300,
+                  "2022-04-20T02:00:00+00:00": 300
+                }
+              },
+              {
+                "scenario": "s2",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": 300,
+                  "2022-04-20T01:00:00+00:00": 300,
+                  "2022-04-20T02:00:00+00:00": 300
+                }
+              },
+              {
+                "scenario": "s3",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": 300,
+                  "2022-04-20T01:00:00+00:00": 300,
+                  "2022-04-20T02:00:00+00:00": 300
+                }
+              }
+            ],
+            "index": {
+              "s1": 1,
+              "s2": 2,
+              "s3": 3
+            }
+          }
+        }
+      ],
+      "constant": {
+        "ts_data": [],
+        "index": {}
+      }
+    },
+    "c3": {
+      "name": "c3",
+      "gc_type": "gt",
+      "is_setpoint": true,
+      "penalty": 1.0,
+      "factors": [
+        {
+          "var_type": "state",
+          "var_tuple": [
+            "dh_sto",
+            ""
+          ],
+          "data": {
+            "ts_data": [
+              {
+                "scenario": "s1",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": 256,
+                  "2022-04-20T01:00:00+00:00": 256,
+                  "2022-04-20T02:00:00+00:00": 256
+                }
+              },
+              {
+                "scenario": "s2",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": 256,
+                  "2022-04-20T01:00:00+00:00": 256,
+                  "2022-04-20T02:00:00+00:00": 256
+                }
+              },
+              {
+                "scenario": "s3",
+                "series": {
+                  "2022-04-20T00:00:00+00:00": 256,
+                  "2022-04-20T01:00:00+00:00": 256,
+                  "2022-04-20T02:00:00+00:00": 256
+                }
+              }
+            ],
+            "index": {
+              "s1": 1,
+              "s2": 2,
+              "s3": 3
+            }
+          }
+        }
+      ],
+      "constant": {
+        "ts_data": [],
+        "index": {}
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes two issues with temperature forecast:

- The initial state of the outside air node is now updated to the first forecast temperature before optimization
- The inflow of the outside air node is now correctly set to changes in temperature, not the absolute values

Also, the hard-coded name for the outside node, "outside", has been replaced by a machinery that allows *any* node to be marked as a node whose inflow should be replaced by the temperature forecast. The GraphQL mutation `ConnectNodeInflowToTemperatureForecast` can be used to mark a node as such.