### PR TITLE
Move settings from AppData\Roaming\ to AppData\Local\ on Windows

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1,7 +1,7 @@
 use crate::graphql::HerttaContext;
 use crate::input_data_base::BaseInputData;
+use crate::settings;
 use crate::time_line_settings::TimeLineSettings;
-use directories::ProjectDirs;
 use juniper::GraphQLObject;
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File};
@@ -16,10 +16,7 @@ pub struct Model {
 }
 
 pub fn make_model_file_path() -> PathBuf {
-    ProjectDirs::from("", "", "hertta")
-        .expect("system should have a home directory")
-        .config_local_dir()
-        .join("model.json")
+    settings::config_path().join("model.json")
 }
 
 pub fn read_model_from_file(file_path: &PathBuf) -> Result<Model, String> {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -105,11 +105,15 @@ pub fn map_from_environment_variables() -> HashMap<String, String> {
     map
 }
 
-pub fn make_settings_file_path() -> PathBuf {
+pub fn config_path() -> PathBuf {
     directories::ProjectDirs::from("", "", "hertta")
         .expect("system should have a home directory")
-        .preference_dir()
-        .join("settings.toml")
+        .config_local_dir()
+        .to_path_buf()
+}
+
+pub fn make_settings_file_path() -> PathBuf {
+    config_path().join("settings.toml")
 }
 
 fn make_config_builder(


### PR DESCRIPTION
This moves the settings file from `...AppData\Roaming\...` to `...AppData\Local\...` on Windows systems.